### PR TITLE
gitprovider: added auth functionality to launch demo

### DIFF
--- a/src/app/launcher/gitprovider-step/gitprovider-step.component.html
+++ b/src/app/launcher/gitprovider-step/gitprovider-step.component.html
@@ -12,11 +12,19 @@
           <i class="fa fa-github"></i>
         </div>
         <div class="col-xs-8 f8launcher-provider-card-information">
+          <!-- Enable Access-Conrtol-Expose-Headers for CORS to test -->
           <h3>Authorized Account</h3>
           <div class="f8launcher-provider-card-information-authorize">
-            <i class="fa fa-ban fa-2x"></i> <span class="f8launcher-username">None</span>
+            <img height="30px" width="30px" [src]="ghAvatar" *ngIf="ghAvatar !== undefined">
+            <span *ngIf="ghLogin !== undefined">{{ghLogin}}</span>
+            <i class="fa fa-ban fa-2x" *ngIf="ghAvatar === undefined"></i>
+            <span class="f8launcher-username" *ngIf="ghLogin === undefined"> None</span>
             <button class="btn btn-primary f8launcher-authorize-account"
-                    (click)="authorize($event)">Authorize Account</button>
+                    (click)="authorizeAccount($event)"
+                    *ngIf="ghToken === undefined">Authorize Account</button>
+            <button class="btn btn-secondary f8launcher-authorize-account"
+                    (click)="changeAccount($event)"
+                    *ngIf="ghToken !== undefined">Change Account</button>
           </div>
           <h4>Organization &amp; Repository</h4>
           <form class="form-horizontal">

--- a/src/app/launcher/gitprovider-step/gitprovider-step.component.ts
+++ b/src/app/launcher/gitprovider-step/gitprovider-step.component.ts
@@ -1,8 +1,18 @@
-import { Component, Host, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Host, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
 
 import { GitProviderService } from '../service/gitprovider.service';
 import { Selection } from '../model/selection.model';
 import { WizardComponent } from '../wizard.component';
+
+import {
+  GitHubRepo,
+  GitHubRepoCommit,
+  GitHubRepoDetails,
+  GitHubRepoLastCommit,
+  GitHubRepoLicense,
+  GitHubUser
+} from '../model/github.model';
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -10,12 +20,39 @@ import { WizardComponent } from '../wizard.component';
   templateUrl: './gitprovider-step.component.html',
   styleUrls: ['./gitprovider-step.component.less']
 })
-export class GitProviderStepComponent implements OnInit {
+export class GitProviderStepComponent implements OnDestroy, OnInit {
+  private _ghAvatar: string;
+  private _ghLogin: string;
+  private _ghToken: string;
+  private subscriptions: Subscription[] = [];
+  private ghUser: GitHubUser;
+
   constructor(@Host() public wizardComponent: WizardComponent,
               private gitProviderService: GitProviderService) {
   }
 
   ngOnInit() {
+    this.subscriptions.push(
+      this.gitProviderService.getToken().subscribe((val) => {
+        if (val !== undefined) {
+          this._ghToken = val;
+        }
+      }));
+
+    this.subscriptions.push(
+      this.gitProviderService.getUser().subscribe((val) => {
+        if (val !== undefined) {
+          this.ghUser = val;
+          this._ghAvatar = this.ghUser.avatar_url;
+          this._ghLogin = this.ghUser.login;
+        }
+      }));
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach((sub) => {
+      sub.unsubscribe();
+    });
   }
 
   /**
@@ -23,15 +60,55 @@ export class GitProviderStepComponent implements OnInit {
    *
    * @param {MouseEvent} $event
    */
-  authorize($event: MouseEvent): void {
+  authorizeAccount($event: MouseEvent): void {
     let url = window.location.origin + this.getParams(this.wizardComponent.selection);
     this.gitProviderService.authorize(url);
   }
+
+  /**
+   * Change GitHub account
+   *
+   * @param {MouseEvent} $event
+   */
+  changeAccount($event: MouseEvent): void {
+    let url = window.location.origin + this.getParams(this.wizardComponent.selection);
+    this.gitProviderService.authorize(url);
+  }
+
+  // Accessors
+
+  get ghAvatar(): string {
+    return this._ghAvatar;
+  }
+
+  get ghLogin(): string {
+    return this._ghLogin;
+  }
+
+  get ghToken(): string {
+    return this._ghToken;
+  }
+
+  // Private
 
   private getParams(selection: Selection) {
     if (selection === undefined) {
       return '';
     }
     return '?selection=' + JSON.stringify(selection);
+  }
+
+  /**
+   * Helper to retrieve request parameters
+   *
+   * @param name The request parameter to retrieve
+   * @returns {any} The request parameter value or null
+   */
+  private getRequestParam(name: string): string {
+    let param = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(window.location.search);
+    if (param !== null) {
+      return decodeURIComponent(param[1]);
+    }
+    return null;
   }
 }

--- a/src/app/launcher/model/github.model.ts
+++ b/src/app/launcher/model/github.model.ts
@@ -1,0 +1,240 @@
+export class GitHubUser {
+  'login': string;
+  'id': number;
+  'avatar_url': string;
+  'gravatar_id': string;
+  'url': string;
+  'html_url': string;
+  'followers_url': string;
+  'following_url': string;
+  'gists_url': string;
+  'starred_url': string;
+  'subscriptions_url': string;
+  'organizations_url': string;
+  'repos_url': string;
+  'events_url': string;
+  'received_events_url': string;
+  'type': string;
+  'site_admin': boolean;
+  'name': string;
+  'company': string;
+  'blog': string;
+  'location': string;
+  'email': string;
+  'hireable': string;
+  'bio': string;
+  'public_repos': number;
+  'public_gists': number;
+  'followers': number;
+  'following': number;
+  'created_at': string;
+  'updated_at': string;
+  'total_private_repos': number;
+  'owned_private_repos': number;
+  'private_gists': number;
+  'disk_usage': number;
+  'collaborators': number;
+  'two_factor_authentication': boolean;
+  'plan': {
+    'name': string;
+    'space': number;
+    'private_repos': number;
+    'collaborators': number;
+  };
+}
+
+export class GitHubOwner {
+  'login': string;
+  'id': number;
+  'avatar_url': string;
+  'gravatar_id': string;
+  'url': string;
+  'html_url': string;
+  'followers_url': string;
+  'following_url': string;
+  'gists_url': string;
+  'starred_url': string;
+  'subscriptions_url': string;
+  'organizations_url': string;
+  'repos_url': string;
+  'events_url': string;
+  'received_events_url': string;
+  'type': string;
+  'site_admin': boolean;
+}
+
+// User repos
+// https://api.github.com/users/almighty/repos
+export class GitHubRepo {
+  'id': number;
+  'name': string;
+  'full_name': string;
+  'owner': GitHubOwner;
+  'private': boolean;
+  'html_url': string;
+  'description': string;
+  'fork': boolean;
+  'url': string;
+  'forks_url': string;
+  'keys_url': string;
+  'collaborators_url': string;
+  'teams_url': string;
+  'hooks_url': string;
+  'issue_events_url': string;
+  'events_url': string;
+  'assignees_url': string;
+  'branches_url': string;
+  'tags_url': string;
+  'blobs_url': string;
+  'git_tags_url': string;
+  'git_refs_url': string;
+  'trees_url': string;
+  'statuses_url': string;
+  'languages_url': string;
+  'stargazers_url': string;
+  'contributors_url': string;
+  'subscribers_url': string;
+  'subscription_url': string;
+  'commits_url': string;
+  'git_commits_url': string;
+  'comments_url': string;
+  'issue_comment_url': string;
+  'contents_url': string;
+  'compare_url': string;
+  'merges_url': string;
+  'archive_url': string;
+  'downloads_url': string;
+  'issues_url': string;
+  'pulls_url': string;
+  'milestones_url': string;
+  'notifications_url': string;
+  'labels_url': string;
+  'releases_url': string;
+  'deployments_url': string;
+  'created_at': string;
+  'updated_at': string;
+  'pushed_at': string;
+  'git_url': string;
+  'ssh_url': string;
+  'clone_url': string;
+  'svn_url': string;
+  'homepage': string;
+  'size': number;
+  'stargazers_count': number;
+  'watchers_count': number;
+  'language': string;
+  'has_issues': boolean;
+  'has_projects': boolean;
+  'has_downloads': boolean;
+  'has_wiki': boolean;
+  'has_pages': boolean;
+  'forks_count': number;
+  'mirror_url': string;
+  'open_issues_count': number;
+  'forks': number;
+  'open_issues': number;
+  'watchers': number;
+  'default_branch': string;
+}
+
+// Repo details
+// https://api.github.com/repos/fabric8-services/fabric8-wit
+export class GitHubRepoDetails extends GitHubRepo {
+  'parent': GitHubRepo;
+  'source': GitHubRepo;
+  'organization': GitHubOwner;
+  'network_count': number;
+  'subscribers_count': number;
+}
+
+// License
+// https://api.github.com/repos/fabric8-services/fabric8-wit/license
+export class GitHubRepoLicense {
+  'name': string;
+  'path': string;
+  'sha': string;
+  'size': number;
+  'url': string;
+  'html_url': string;
+  'git_url': string;
+  'download_url': string;
+  'type': string;
+  'content': string;
+  'encoding': string;
+  '_links': {
+    'self': string;
+    'git': string;
+    'html': string;
+  };
+  'license': {
+    'key': string;
+    'name': string;
+    'spdx_id': string;
+    'url': string;
+    'featured': boolean;
+  };
+}
+
+// Last commit
+// https://api.github.com/repos/fabric8-services/fabric8-wit/git/refs/heads/master
+export class GitHubRepoLastCommit {
+  'ref': string;
+  'url': string;
+  'object': {
+    'sha': string;
+    'type': string;
+    'url': string;
+  };
+}
+
+// Commit
+// https://api.github.com/repos/fabric8-services/fabric8-wit/commits{/sha}
+export class GitHubRepoCommit {
+  'sha': string;
+  'commit': {
+    'author': {
+      'name': string;
+      'email': string;
+      'date': string;
+    };
+    'committer': {
+      'name': string;
+      'email': string;
+      'date': string;
+    };
+    'message': string;
+    'tree': {
+      'sha': string;
+      'url': string;
+    };
+    'url': string;
+    'comment_count': number;
+  };
+  'url': string;
+  'html_url': string;
+  'comments_url': string;
+  'author': GitHubOwner;
+  'committer': GitHubOwner;
+  'parents': [{
+      'sha': string;
+      'url': string;
+      'html_url': string;
+  }];
+  'stats': {
+    'total': number;
+    'additions': number;
+    'deletions': number;
+  };
+  'files': [{
+    'sha': string;
+    'filename': string;
+    'status': string;
+    'additions': number;
+    'deletions': number;
+    'changes': number;
+    'blob_url': string;
+    'raw_url': string;
+    'contents_url': string;
+    'patch': string;
+  }];
+}

--- a/src/app/launcher/service/gitprovider.service.ts
+++ b/src/app/launcher/service/gitprovider.service.ts
@@ -1,3 +1,14 @@
+import { Observable } from 'rxjs';
+
+import {
+  GitHubRepo,
+  GitHubRepoCommit,
+  GitHubRepoDetails,
+  GitHubRepoLastCommit,
+  GitHubRepoLicense,
+  GitHubUser
+} from '../model/github.model';
+
 /**
  * Abstract GitHub provider service provided to ensure consumer implements this pattern
  */
@@ -8,4 +19,26 @@ export abstract class GitProviderService {
    * @param {string} redirectUrl The URL to return back to from GitHub
    */
   abstract authorize(redirectUrl: string): void;
+
+  /**
+   * Get GitHub repo details for given full name
+   *
+   * @param fullName The GitHub full name (e.g., fabric8-services/fabric8-wit)
+   * @returns {Observable<GitHubRepoDetails>}
+   */
+  abstract getRepoDetailsByFullName(fullName: string): Observable<GitHubRepoDetails>;
+
+  /**
+   * Get authenticate GitHub user
+   *
+   * @returns {Observable<GitHubUser>}
+   */
+  abstract getUser(): Observable<GitHubUser>;
+
+  /**
+   * Get authentication token
+   *
+   * @returns {Observable<any>}
+   */
+  abstract getToken(): Observable<any>;
 }

--- a/src/demo/service/demo-gitprovider.service.ts
+++ b/src/demo/service/demo-gitprovider.service.ts
@@ -1,13 +1,31 @@
 import { Injectable } from '@angular/core';
+import { Http } from '@angular/http';
+import { Observable } from 'rxjs';
 
-import { Selection } from '../../app/launcher/model/selection.model';
 import { GitProviderService } from '../../app/launcher/launcher.module';
+import {
+  GitHubRepo,
+  GitHubRepoCommit,
+  GitHubRepoDetails,
+  GitHubRepoLastCommit,
+  GitHubRepoLicense,
+  GitHubUser
+} from '../../app/launcher/model/github.model';
 
+// Enable Access-Conrtol-Expose-Headers for CORS to test
 @Injectable()
 export class DemoGitProviderService implements GitProviderService {
-  private clientId: string = 'a59372e52d3128f59dfb'; // Test app
+  private static readonly HEADERS = new Headers({
+    'Content-Type': 'application/json',
+    'Accept': 'application/vnd.github.v3+json'
+  });
 
-  constructor() {
+  private clientId: string = 'a59372e52d3128f59dfb'; // Temp test app
+  private clientSecret: string = 'd78cccc1a3310d06b7b7debe7e9f0df7bcda16a5'; // Temp test app
+  private gitHubUrl: string = 'https://api.github.com';
+  private token: string;
+
+  constructor(private http: Http) {
   }
 
   authorize(redirectUrl: string): void {
@@ -16,8 +34,105 @@ export class DemoGitProviderService implements GitProviderService {
     this.redirectToAuth(url);
   }
 
-  private getParams(selection: Selection) {
-    return '?selection=' + JSON.stringify(selection);
+  /**
+   * Get GitHub repo details for given full name
+   *
+   * @param fullName The GitHub full name (e.g., fabric8-services/fabric8-wit)
+   * @returns {Observable<GitHubRepoDetails>}
+   */
+  getRepoDetailsByFullName(fullName: string): Observable<GitHubRepoDetails> {
+    let url = `${this.gitHubUrl}/repos/${fullName}`;
+    return this.getHeaders()
+      .switchMap(newHeaders => this.http
+        .get(url, { headers: newHeaders }))
+      .map(response => {
+        return response.json() as GitHubRepoDetails;
+      });
+  }
+
+  /**
+   * Get authenticate GitHub user
+   *
+   * @returns {Observable<GitHubUser>}
+   */
+  getUser(): Observable<GitHubUser> {
+    let url = `${this.gitHubUrl}/user`;
+    return this.getHeaders()
+      .switchMap(newHeaders => this.http
+        .get(url, { headers: newHeaders }))
+      .map(response => {
+        return response.json() as GitHubUser;
+      });
+  }
+
+  /**
+   * Get authentication token
+   *
+   * @returns {Observable<any>}
+   */
+  getToken(): Observable<any> {
+    if (this.token !== undefined) {
+      return Observable.of(this.token);
+    }
+    let code = this.getRequestParam('code');
+    if (code === null) {
+      return Observable.empty();
+    }
+    let url = 'https://github.com/login/oauth/access_token?' + 'client_id=' +
+      this.clientId + '&client_secret=' + this.clientSecret + '&code=' + code;
+    return this.http.get(url)
+      .map((response) => {
+        let body = response.text();
+        let accessToken = this.getParamFromString('access_token', body);
+        if (accessToken !== null) {
+          this.token = accessToken;
+        }
+        return this.token;
+      });
+  }
+
+  // Private
+
+  // Get GitHub headers for authentified user
+  private getHeaders(): Observable<any> {
+    if (this.token !== undefined) {
+      let newHeaders: any = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/vnd.github.v3+json',
+        'Authorization': `token ${this.token}`
+      };
+      return Observable.of(newHeaders);
+    }
+    return this.getToken().map(token => {
+      let newHeaders: any = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/vnd.github.v3+json',
+        'Authorization': `token ${token}`
+      };
+      return newHeaders;
+    });
+  }
+
+  /**
+   * Helper to retrieve request parameters
+   *
+   * @param name The request parameter to retrieve
+   * @returns {any} The request parameter value or null
+   */
+  private getRequestParam(name: string): string {
+    let param = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(window.location.search);
+    if (param !== null) {
+      return decodeURIComponent(param[1]);
+    }
+    return null;
+  }
+
+  private getParamFromString(name: string, val: string): string {
+    let param = (new RegExp(encodeURIComponent(name) + '=([^&]*)')).exec(val);
+    if (param !== null) {
+      return decodeURIComponent(param[1]);
+    }
+    return null;
   }
 
   private redirectToAuth(url: string) {


### PR DESCRIPTION
To test, select runtime, mission, and version. Then select the "Authorize Account" button from the "Authorize Git Provider" step.

After authorizing with GitHub, and redirecting back to the demo, the user's avatar, user name, and "Change Account" button are shown in the "Authorize Git Provider" step.

Note: Access-Conrtol-Expose-Headers must be enabled for CORS. Otherwise, the demo cannot retrieve the user's GitHub token. This won't be the case for OSIO as REST APIs exist for this.