### PR TITLE
chore(app-launcher): simplified how steps are shown

### DIFF
--- a/src/app/launcher/launcher.module.ts
+++ b/src/app/launcher/launcher.module.ts
@@ -53,4 +53,3 @@ export { Mission } from './model/mission.model';
 export { Runtime } from './model/runtime.model';
 export { Cluster } from './model/cluster.model';
 export { Pipeline } from './model/pipeline.model';
-export { Step } from './step-indicator/step';

--- a/src/app/launcher/step-indicator/step-indicator.component.html
+++ b/src/app/launcher/step-indicator/step-indicator.component.html
@@ -1,7 +1,8 @@
 <div class="f8launcher-vertical-bar_application-title">
   <input class="f8launcher-vertical-bar_application-title-input" type="next" name="applicationTitle" placeholder="New Application">
 </div>
-<div class="f8launcher-vertical-bar">
+<div class="f8launcher-vertical-bar"
+     [ngClass]="{'in-progress': inProgress === true}">
   <a class="f8launcher-vertical-bar_steps--item {{step.styleClass}}" href="javascript:void(0)"
      [class.active]="wizardComponent.selectedSection === step.id"
      [ngClass]="{'hide': step.hidden === true}"

--- a/src/app/launcher/step-indicator/step-indicator.component.ts
+++ b/src/app/launcher/step-indicator/step-indicator.component.ts
@@ -15,28 +15,17 @@ import { WizardComponent } from '../wizard.component';
   styleUrls: ['./step-indicator.component.less']
 })
 export class StepIndicatorComponent implements OnInit {
+  /**
+   * Show appropriate style while steps are in progress of being shown
+   *
+   * @type {boolean}
+   */
+  @Input() inProgress: boolean = false;
+
   constructor(@Host() public wizardComponent: WizardComponent) {
   }
 
   ngOnInit() {
-  }
-
-  /**
-   * Helper to determine if step should be shown
-   *
-   * @param {string} id The step ID
-   * @returns {boolean} True if step should be shown
-   */
-  isStepHidden(id: string): boolean {
-    let result = false;
-    for (let i = 0; i < this.wizardComponent.steps.length; i++) {
-      let step = this.wizardComponent.steps[i];
-      if (id === step.id) {
-        result = (step.hidden === true);
-        break;
-      }
-    }
-    return result;
   }
 
   /**

--- a/src/app/launcher/step-indicator/step.ts
+++ b/src/app/launcher/step-indicator/step.ts
@@ -1,8 +1,0 @@
-export class Step {
-  id: string;
-  completed?: boolean;
-  hidden?: boolean;
-  showAfterCompleted?: string[];
-  stleClass?: string;
-  title: string;
-}

--- a/src/app/launcher/wizard-step.ts
+++ b/src/app/launcher/wizard-step.ts
@@ -19,11 +19,6 @@ export abstract class WizardStep {
   @Input() hidden: boolean = false;
 
   /**
-   * A string array of steps that must be completed in order for this step to be shown -- overrides hidden
-   */
-  @Input() showAfterCompleted: string[];
-
-  /**
    * Style class for the step container
    */
   @Input() styleClass: string;

--- a/src/app/launcher/wizard.component.html
+++ b/src/app/launcher/wizard.component.html
@@ -3,11 +3,13 @@
     <div *ngIf="showNextSteps; then showNextStepsTemplate else showStepsTemplate"></div>
     <ng-template #showStepsTemplate>
       <div class="f8launcher-container_nav">
-        <f8launcher-step-indicator #stepIndicator></f8launcher-step-indicator>
+        <f8launcher-step-indicator #stepIndicator
+          [inProgress]="!(missionRuntimeStep.completed === true && targetEnvStep.completed === true)">
+        </f8launcher-step-indicator>
       </div>
       <div class="f8launcher-container_main">
         <section id="section0" class="f8launcher-container_main-start"></section>
-        <f8launcher-missionruntime-step
+        <f8launcher-missionruntime-step #missionRuntimeStep
             [id]="'MissionRuntime'"
             [styleClass]="'mission-runtime'"
             [title]="'Select Mission & Runtime'">
@@ -20,40 +22,38 @@
             [title]="'Dependency Checker'">
         </f8launcher-dependencychecker-step>
 -->
-        <f8launcher-targetenvironment-step
+        <f8launcher-targetenvironment-step #targetEnvStep
           [id]="'TargetEnvironment'"
           [styleClass]="'target-environment'"
           [title]="'Select Target Environment'">
         </f8launcher-targetenvironment-step>
-        <f8launcher-releasestrategy-step
-          [hidden]="true"
+        <f8launcher-releasestrategy-step #releaSestrategyStep
+          [hidden]="!(missionRuntimeStep.completed === true && targetEnvStep.completed === true
+            && summary?.targetEnvironment === 'os')"
           [id]="'ReleaseStrategy'"
-          [showAfterCompleted]="['MissionRuntime', 'TargetEnvironment']"
+          [ngClass]="{'hidden': releaSestrategyStep.hidden}"
           [styleClass]="'release-strategy'"
-          [title]="'Select Release Strategy'"
-          *ngIf="!stepIndicator.isStepHidden('ReleaseStrategy')">
+          [title]="'Select Release Strategy'">
         </f8launcher-releasestrategy-step>
-        <f8launcher-gitprovider-step
-          [hidden]="true"
+        <f8launcher-gitprovider-step #gitProviderStep
+          [hidden]="!(missionRuntimeStep.completed === true && targetEnvStep.completed === true)"
           [id]="'GitProvider'"
-          [showAfterCompleted]="['MissionRuntime', 'TargetEnvironment']"
+          [ngClass]="{'hidden': gitProviderStep.hidden}"
           [styleClass]="'git-provider'"
-          [title]="'Authorize Git Provider'"
-          *ngIf="!stepIndicator.isStepHidden('GitProvider')">
+          [title]="'Authorize Git Provider'">
         </f8launcher-gitprovider-step>
-        <f8launcher-projectsummary-step
-          [hidden]="true"
+        <f8launcher-projectsummary-step #projectSummaryStep
+          [hidden]="!(missionRuntimeStep.completed === true && targetEnvStep.completed === true)"
           [id]="'ProjectSummary'"
-          [showAfterCompleted]="['MissionRuntime', 'TargetEnvironment']"
+          [ngClass]="{'hidden': projectSummaryStep.hidden}"
           [styleClass]="'project-summary'"
-          [title]="'Confirm Project Summary'"
-          *ngIf="!stepIndicator.isStepHidden('ProjectSummary')">
+          [title]="'Confirm Project Summary'">
         </f8launcher-projectsummary-step>
       </div>
     </ng-template>
     <ng-template #showNextStepsTemplate>
-      <f8launcher-activatebooster-step></f8launcher-activatebooster-step>
-      <f8launcher-newproject-step></f8launcher-newproject-step>
+      <f8launcher-activatebooster-step *ngIf="summary?.targetEnvironment === 'zip'"></f8launcher-activatebooster-step>
+      <f8launcher-newproject-step *ngIf="summary?.targetEnvironment === 'os'"></f8launcher-newproject-step>
     </ng-template>
   </div>
 </div>

--- a/src/app/launcher/wizard.component.ts
+++ b/src/app/launcher/wizard.component.ts
@@ -8,7 +8,6 @@ import { Router } from '@angular/router';
 
 import { Selection } from './model/selection.model';
 import { Summary } from './model/summary.model';
-import { Step } from './step-indicator/step';
 import { StepIndicatorComponent } from './step-indicator/step-indicator.component';
 import { WizardStep } from './wizard-step';
 
@@ -131,8 +130,8 @@ export class WizardComponent implements OnInit {
    * @param {string} id The step ID
    * @returns {Step} The step for the given ID
    */
-  getStep(id: string): Step {
-    let result: Step;
+  getStep(id: string): WizardStep {
+    let result: WizardStep;
     for (let i = 0; i < this.steps.length; i++) {
       let step = this.steps[i];
       if (id === step.id) {
@@ -151,14 +150,6 @@ export class WizardComponent implements OnInit {
     if (summaryStep.completed === true) {
       this.summaryCompleted = true;
       return;
-    }
-
-    // Show after steps completed
-    this.showStepsAfterCompleted();
-
-    // Skip pipelines for zip strategy
-    if (this.summary.targetEnvironment === 'zip') {
-      this.getStep('ReleaseStrategy').hidden = true;
     }
     setTimeout(() => {
       this.stepIndicator.navToNextStep();
@@ -179,23 +170,5 @@ export class WizardComponent implements OnInit {
       return decodeURIComponent(param[1]);
     }
     return null;
-  }
-
-  // Show hidden steps after previous steps have been completed
-  private showStepsAfterCompleted(): void {
-    for (let i = 0; i < this.steps.length; i++) {
-      let step = this.steps[i];
-      if (step.showAfterCompleted !== undefined) {
-        let result = false;
-        // Iterate over potentally completed steps
-        for (let k = 0; k < step.showAfterCompleted.length; k++) {
-          let dependency = this.getStep(step.showAfterCompleted[k]);
-          if (dependency.completed !== true) {
-            result = true;
-          }
-        }
-        step.hidden = result;
-      }
-    }
   }
 }


### PR DESCRIPTION
Simplified how steps are hidden and shown via the HTML template. The two 'next steps" are now shown (mutually exclusive) based on the target environment selection.