### PR TITLE
app-launcher: add inline-editable application title feature

### DIFF
--- a/src/app/launcher/model/selection.model.ts
+++ b/src/app/launcher/model/selection.model.ts
@@ -1,15 +1,16 @@
 export class Selection {
-  missionId: string;
-  runtimeId: string;
-  runtimeVersion: string;
-  targetEnvironment: string;
+  applicationTitle?: string;
   clusterId?: string;
+  groupId: string;
+  mavenArtifact: string;
+  missionId: string;
+  organization: string;
   pipelineId: string;
   projectName: string;
-  mavenArtifact: string;
   projectVersion: string;
-  groupId: string;
-  spacePath?: string;
-  organization: string;
   repository: string;
+  runtimeId: string;
+  runtimeVersion: string;
+  spacePath?: string;
+  targetEnvironment: string;
 }

--- a/src/app/launcher/model/summary.model.ts
+++ b/src/app/launcher/model/summary.model.ts
@@ -4,17 +4,18 @@ import { Pipeline } from './pipeline.model';
 import { Cluster } from './cluster.model';
 
 export class Summary {
+  applicationTitle?: string;
+  cluster?: Cluster;
+  groupId: string;
+  mavenArtifact: string;
   mission: Mission;
+  organization: string;
+  pipeline: Pipeline;
+  projectName: string;
+  projectVersion: string;
+  spacePath?: string;
+  repository: string;
   runtime: Runtime;
   runtimeVersion: string;
   targetEnvironment: string;
-  cluster?: Cluster;
-  pipeline: Pipeline;
-  projectName: string;
-  mavenArtifact: string;
-  projectVersion: string;
-  groupId: string;
-  spacePath?: string;
-  organization: string;
-  repository: string;
 }

--- a/src/app/launcher/step-indicator/step-indicator.component.html
+++ b/src/app/launcher/step-indicator/step-indicator.component.html
@@ -1,5 +1,9 @@
-<div class="f8launcher-vertical-bar_application-title">
-  <input class="f8launcher-vertical-bar_application-title-input" type="next" name="applicationTitle" placeholder="New Application">
+<div class="f8launcher-vertical-bar_application-title">\
+  <input class="f8launcher-vertical-bar_application-title-input"
+         name="applicationTitle" placeholder="New Application" type="text"
+         [(ngModel)]="applicationTitle"
+         (keyup.enter)="$event.target.blur();"
+         (ngModelChange)="updateAppTitle()">
 </div>
 <div class="f8launcher-vertical-bar"
      [ngClass]="{'in-progress': inProgress === true}">

--- a/src/app/launcher/step-indicator/step-indicator.component.ts
+++ b/src/app/launcher/step-indicator/step-indicator.component.ts
@@ -6,6 +6,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
+import { Selection } from '../model/selection.model';
 import { WizardComponent } from '../wizard.component';
 
 @Component({
@@ -22,11 +23,26 @@ export class StepIndicatorComponent implements OnInit {
    */
   @Input() inProgress: boolean = false;
 
+  private _applicationTitle: string;
+
   constructor(@Host() public wizardComponent: WizardComponent) {
   }
 
   ngOnInit() {
+    this.restoreSummary();
   }
+
+  // Accessors
+
+  get applicationTitle(): string {
+    return this._applicationTitle;
+  }
+
+  set applicationTitle(applicationTitle: string) {
+    this._applicationTitle = applicationTitle;
+  }
+
+  // Steps
 
   /**
    * Navigate to next step
@@ -48,5 +64,25 @@ export class StepIndicatorComponent implements OnInit {
    */
   navToStep(id: string) {
     document.getElementById(id).scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  /**
+   * Update application title for wizard component
+   */
+  updateAppTitle(): void {
+    if (this.wizardComponent.summary !== undefined) {
+      this.wizardComponent.summary.applicationTitle = this._applicationTitle;
+    }
+  }
+
+  // Private
+
+  // Restore mission & runtime summary
+  private restoreSummary(): void {
+    let selection: Selection = this.wizardComponent.selectionParams;
+    if (selection === undefined) {
+      return;
+    }
+    this.applicationTitle = selection.applicationTitle;
   }
 }

--- a/src/app/launcher/wizard.component.ts
+++ b/src/app/launcher/wizard.component.ts
@@ -40,6 +40,11 @@ export class WizardComponent implements OnInit {
 
   // Accessors
 
+  /**
+   * Returns the current step ID
+   *
+   * @returns {string} The current step ID
+   */
   get selectedSection(): string {
     return this._selectedSection;
   }


### PR DESCRIPTION
This enables the inline-editable feature for the application title. It also restores the application title when returning from GitHub auth.