### PR TITLE
app-launcher: added functionality to summary page

### DIFF
--- a/config/webpack.demo.js
+++ b/config/webpack.demo.js
@@ -209,7 +209,7 @@ module.exports = {
     new AotPlugin({
       entryModule: helpers.root('src/demo/app.module.ts#AppModule'),
       tsConfigPath: helpers.root('tsconfig-aot.json')
-    })
+    }),
 
     /**
      * Plugin: copy-webpack-plugin
@@ -217,8 +217,9 @@ module.exports = {
      *
      * See: https://github.com/kevlened/copy-webpack-plugin
      */
-    // new CopyWebpackPlugin([{
-    //   from: helpers.root('README.md')
-    // }]),
+    new CopyWebpackPlugin([{
+      from: helpers.root('./src/assets/images'),
+      to: helpers.root('dist-demo/assets/images')
+    }]),
   ]
 };

--- a/src/app/launcher/activate-booster/activate-booster.component.html
+++ b/src/app/launcher/activate-booster/activate-booster.component.html
@@ -22,8 +22,8 @@
             </div>
             <div class="card-pf-body">
               <pre>
-                $ unzip {{wizardComponent.summary.applicationTitle}}.zip
-                $ cd {{wizardComponent.summary.applicationTitle}}
+                $ unzip {{wizardComponent.summary.projectName}}.zip
+                $ cd {{wizardComponent.summary.projectName}}
               </pre>
             </div>
           </div>

--- a/src/app/launcher/gitprovider-step/gitprovider-step.component.html
+++ b/src/app/launcher/gitprovider-step/gitprovider-step.component.html
@@ -19,32 +19,38 @@
           <!-- Enable Access-Conrtol-Expose-Headers for CORS to test -->
           <h3>Authorized Account</h3>
           <div class="f8launcher-provider-card-information-authorize">
-            <img height="30px" width="30px" [src]="ghAvatar" *ngIf="ghAvatar !== undefined">
-            <span *ngIf="ghLogin !== undefined">{{ghLogin}}</span>
-            <i class="fa fa-ban fa-2x" *ngIf="ghAvatar === undefined"></i>
-            <span class="f8launcher-username" *ngIf="ghLogin === undefined"> None</span>
+            <img height="30px" width="30px" [src]="wizardComponent.summary.githubAvatar"
+                 *ngIf="wizardComponent.summary?.githubAvatar !== undefined">
+            <span *ngIf="wizardComponent.summary?.githubLogin !== undefined">
+              {{wizardComponent.summary?.githubLogin}}
+            </span>
+            <i class="fa fa-ban fa-2x" *ngIf="wizardComponent.summary?.githubAvatar === undefined"></i>
+            <span class="f8launcher-username" *ngIf="wizardComponent.summary?.githubLogin === undefined"> None</span>
             <button class="btn btn-primary btn-lg f8launcher-authorize-account"
                     (click)="authorizeAccount($event)"
-                    *ngIf="ghToken === undefined">Log In &amp; Authorize Account</button>
+                    *ngIf="wizardComponent.summary?.githubLogin === undefined">Log In &amp; Authorize Account</button>
             <button class="btn btn-default btn-lg f8launcher-authorize-account"
                     (click)="changeAccount($event)"
-                    *ngIf="ghToken !== undefined">Change Account</button>
+                    *ngIf="wizardComponent.summary?.githubLogin !== undefined">Change Account</button>
           </div>
           <form class="form-horizontal">
             <div class="form-group">
-              <label for="orgDropdown" class="col-sm-2 control-label">Organization</label>
+              <label for="ghOrg" class="col-sm-2 control-label">Organization</label>
               <div class="col-sm-10">
-                <select class="form-control">
-                  <option>fabric8-ui</option>
-                  <option>fabric8-launcher</option>
-                  <option>PatternFly</option>
+                <select id="ghOrg" class="form-control" name="ghOrg"
+                        [(ngModel)]="wizardComponent.summary.githubOrg"
+                        (ngModelChange)="updateGithubSelection()">
+                  <option *ngFor="let org of ghOrgs">{{org.name}}</option>
                 </select>
               </div>
             </div>
             <div class="form-group">
-              <label for="repositoryName" class="col-sm-2 control-label">Repository</label>
+              <label for="ghRepo" class="col-sm-2 control-label">Repository</label>
               <div class="col-sm-10">
-                <input type="text" class="form-control" id="orgDropdown">
+                <input id="ghRepo" class="form-control" name="ghRepo" type="text"
+                       placeholder="Enter Repository"
+                       [(ngModel)]="wizardComponent.summary.githubRepo"
+                       (ngModelChange)="updateGithubSelection()">
               </div>
             </div>
           </form>

--- a/src/app/launcher/launcher.module.ts
+++ b/src/app/launcher/launcher.module.ts
@@ -61,6 +61,7 @@ export { Runtime } from './model/runtime.model';
 export { Cluster } from './model/cluster.model';
 export { Pipeline } from './model/pipeline.model';
 export { Progress } from './model/progress.model';
+export { Summary } from './model/summary.model';
 
 // Services
 export { ClusterService } from './service/cluster.service';
@@ -68,3 +69,4 @@ export { GitProviderService } from './service/gitprovider.service';
 export { MissionRuntimeService } from './service/mission-runtime.service';
 export { PipelineService } from './service/pipeline.service';
 export { ProjectProgressService } from './service/project-progress.service';
+export { ProjectSummaryService } from './service/project-summary.service';

--- a/src/app/launcher/mission-runtime-step/mission-runtime-step.component.ts
+++ b/src/app/launcher/mission-runtime-step/mission-runtime-step.component.ts
@@ -56,10 +56,20 @@ export class MissionRuntimeStepComponent extends WizardStep implements OnInit, O
 
   // Accessors
 
+  /**
+   * Returns a list of missions to display
+   *
+   * @returns {Mission[]} The missions to display
+   */
   get missions(): Mission[] {
     return this._missions;
   }
 
+  /**
+   * Returns a list of runtimes to display
+   *
+   * @returns {Runtime[]} The runtimes to display
+   */
   get runtimes(): Runtime[] {
     return this._runtimes;
   }
@@ -91,7 +101,6 @@ export class MissionRuntimeStepComponent extends WizardStep implements OnInit, O
    * Navigate to next step
    */
   navToNextStep(): void {
-    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
     this.wizardComponent.navToNextStep();
   }
 
@@ -100,9 +109,14 @@ export class MissionRuntimeStepComponent extends WizardStep implements OnInit, O
     this.runtimeId = undefined;
     this.wizardComponent.summary.mission = undefined;
     this.wizardComponent.summary.runtime = undefined;
+    this.initCompleted();
   }
 
   // Private
+
+  private initCompleted(): void {
+    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
+  }
 
   // Restore mission & runtime summary
   private restoreSummary(): void {
@@ -111,7 +125,7 @@ export class MissionRuntimeStepComponent extends WizardStep implements OnInit, O
       return;
     }
     this.missionId = selection.missionId;
-    this.missionId = selection.runtimeId;
+    this.runtimeId = selection.runtimeId;
 
     this.missions.forEach((val) => {
       if (this.missionId === val.missionId) {
@@ -124,15 +138,18 @@ export class MissionRuntimeStepComponent extends WizardStep implements OnInit, O
         this.updateVersionSelection(val, selection.runtimeVersion);
       }
     });
+    this.initCompleted();
   }
 
   private updateMissionSelection(val: Mission): void {
     this.wizardComponent.summary.mission = val;
+    this.initCompleted();
   }
 
   private updateRuntimeSelection(val: Runtime): void {
     this.wizardComponent.summary.runtime = val;
     this.wizardComponent.summary.runtime.version = (val.version !== undefined) ? val.version : val.versions[0];
+    this.initCompleted();
   }
 
   private updateVersionSelection(val: Runtime, version: string): void {

--- a/src/app/launcher/model/mission.model.ts
+++ b/src/app/launcher/model/mission.model.ts
@@ -1,7 +1,8 @@
 export class Mission {
+  description: string;
   missionId: string;
   suggested?: boolean;
-  title: string;
-  description: string;
   supportedRuntimes: string[];
+  title: string;
+  url?: string;
 }

--- a/src/app/launcher/model/runtime.model.ts
+++ b/src/app/launcher/model/runtime.model.ts
@@ -1,9 +1,10 @@
 export class Runtime {
-  runtimeId: string;
-  title: string;
   description: string;
   logo: string;
+  runtimeId: string;
   supportedMissions: string[];
+  title: string;
   version?: string; // Menu selection
   versions: string[];
+  url?: string;
 }

--- a/src/app/launcher/model/selection.model.ts
+++ b/src/app/launcher/model/selection.model.ts
@@ -1,16 +1,13 @@
 export class Selection {
-  applicationTitle?: string;
-  clusterId?: string;
+  githubOrg?: string;
+  githubRepo?: string;
   groupId: string;
-  mavenArtifact: string;
-  missionId: string;
-  organization: string;
-  pipelineId: string;
-  projectName: string;
-  projectVersion: string;
-  repository: string;
-  runtimeId: string;
-  runtimeVersion: string;
+  missionId?: string;
+  pipelineId?: string;
+  projectName?: string;
+  projectVersion?: string;
+  runtimeId?: string;
+  runtimeVersion?: string;
   spacePath?: string;
-  targetEnvironment: string;
+  targetEnvironment?: string;
 }

--- a/src/app/launcher/model/summary.model.ts
+++ b/src/app/launcher/model/summary.model.ts
@@ -4,8 +4,11 @@ import { Pipeline } from './pipeline.model';
 import { Cluster } from './cluster.model';
 
 export class Summary {
-  applicationTitle?: string;
   cluster?: Cluster;
+  githubAvatar?: string;
+  githubLogin?: string;
+  githubOrg?: string;
+  githubRepo?: string;
   groupId: string;
   mavenArtifact: string;
   mission: Mission;

--- a/src/app/launcher/project-summary-step/project-summary-step.component.html
+++ b/src/app/launcher/project-summary-step/project-summary-step.component.html
@@ -17,14 +17,15 @@
             </div>
             <div class="card-pf-body card-column">
               <div class="card-column-60">
-                <b>Eclipse Vert.x</b>
-                <b class="pull-right">v2.4</b>
-                <p>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore...<a href="#">more</a>
+                <b>{{wizardComponent.summary?.runtime?.title}}</b>
+                <b class="pull-right">{{wizardComponent.summary?.runtime?.version}}</b>
+                <p>{{wizardComponent.summary?.runtime?.description}}
+                  <a [href]="wizardComponent.summary?.runtime?.url" target="_blank"
+                     *ngIf="wizardComponent.summary?.runtime?.url !== undefined">more</a>
                 </p>
               </div>
-              <div class="card-column-40">
-                <img src="../../../assets/images/vertx.svg" />
+              <div class="card-column-40" *ngIf="wizardComponent.summary?.runtime?.logo !== undefined">
+                <img [src]="wizardComponent.summary?.runtime?.logo">
               </div>
             </div>
           </div>
@@ -38,9 +39,10 @@
             </div>
             <div class="card-pf-body card-column">
               <div class="card-column-single">
-                <b>Basic Application</b>
-                <p>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore...<a href="#">more</a>
+                <b>{{wizardComponent.summary?.mission?.title}}</b>
+                <p>{{wizardComponent.summary?.mission?.description}}
+                  <a [href]="wizardComponent.summary?.mission?.url" target="_blank"
+                     *ngIf="wizardComponent.summary?.mission?.url !== undefined">more</a>
                 </p>
               </div>
             </div>
@@ -49,55 +51,64 @@
       </div>
     </div>
   </div>
-  <div class="container-fluid container-cards-pf">
+  <div class="container-fluid container-cards-pf" *ngIf="wizardComponent.summary?.targetEnvironment === 'os'">
     <div class="row row-cards-pf">
       <div class="col-xs-12">
         <div class="card-pf">
-          <div class="card-pf-heading">
-            <h2 class="card-pf-title">
-              Pipeline
-            </h2>
-          </div>
-          <div class="card-pf-body">
-            <div class="list-group list-view-pf list-view-pf-view">
-              <div class="list-group-item">
-                <div class="list-group-item-header">
-                  <div class="list-view-pf-main-info">
-                    <div class="list-view-pf-body">
-                      <div class="list-view-pf-description">
-                        <div class="list-group-item-heading">
-                          <b>Name of Pipeline</b>
-                        </div>
-                        <div class="list-group-item-text">
-                          <b>5</b> Stages
-                        </div>
-                        <div class="list-view-pf-additional-info">
-                          <div class="list-view-pf-additional-info-item">
-                            A slightly longer description of this pipeline's capabilities and usage...<a href="#">more</a>
+          <div *ngIf="wizardComponent.summary?.pipeline === undefined;
+                      then showNoPipelineTemplate else showPipelineTemplate"></div>
+          <ng-template #showNoPipelineTemplate>
+            <div class="card-pf-body f8launcher-project-summary-data-unavailable">
+              <span class="fa fa-ban"></span>
+              <h2>No Pipeline</h2>
+              <p>To proceed with setting up this application, there must be a selected pipeline</p>
+              <button class="btn btn-default btn-lg f8launcher-authorize-account"
+                      (click)="navToStep('ReleaseStrategy')">Select Pipeline</button>
+            </div>
+          </ng-template>
+          <ng-template #showPipelineTemplate>
+            <div class="card-pf-heading">
+              <h2 class="card-pf-title">
+                Pipeline
+              </h2>
+            </div>
+            <div class="card-pf-body">
+              <div class="list-group list-view-pf list-view-pf-view">
+                <div class="list-group-item">
+                  <div class="list-group-item-header">
+                    <div class="list-view-pf-main-info">
+                      <div class="list-view-pf-body">
+                        <div class="list-view-pf-description">
+                          <div class="list-group-item-heading">
+                            <b>{{wizardComponent.summary?.pipeline?.name}}</b>
+                          </div>
+                          <div class="list-group-item-text">
+                            <b>{{wizardComponent.summary?.pipeline?.stages.length}}</b> Stages
+                          </div>
+                          <div class="list-view-pf-additional-info">
+                            <div class="list-view-pf-additional-info-item">
+                              {{wizardComponent.summary?.pipeline?.description}}
+                            </div>
                           </div>
                         </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div class="list-group-item-container container-fluid">
-                  <div class="row">
-                    <div class="col-md-12 f8launcher-pipeline-stages">
-                      <span class="f8launcher-pipeline-stages--line">Stage Name</span>
-                      <span class="f8launcher-pipeline-stages--arrow"></span>
-                      <span class="f8launcher-pipeline-stages--line">Stage Name</span>
-                      <span class="f8launcher-pipeline-stages--arrow"></span>
-                      <span class="f8launcher-pipeline-stages--line">Stage Name</span>
-                      <span class="f8launcher-pipeline-stages--arrow"></span>
-                      <span class="f8launcher-pipeline-stages--line">Stage Name</span>
-                      <span class="f8launcher-pipeline-stages--arrow"></span>
-                      <span class="f8launcher-pipeline-stages--line">Stage Name</span>
+                  <div class="list-group-item-container container-fluid">
+                    <div class="row">
+                      <div class="col-md-12 f8launcher-pipeline-stages">
+                        <ng-container *ngFor="let stage of wizardComponent.summary?.pipeline?.stages; let i = index">
+                          <span class="f8launcher-pipeline-stages--line">{{stage}}</span>
+                          <span class="f8launcher-pipeline-stages--arrow"
+                                *ngIf="i !== wizardComponent.summary?.pipeline?.stages.length - 1"></span>
+                        </ng-container>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
+          </ng-template>
         </div>
       </div>
     </div>
@@ -115,36 +126,45 @@
             <div class="card-column-single">
               <form class="form-horizontal">
                 <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-4 control-label">Project Name</label>
+                  <label class="col-xs-4 control-label">Project Name</label>
                   <div class="col-xs-8 f8launcher-project-summary-data-field f8launcher-application-title">
                     <input class="f8launcher-project-summary-data-field_input f8launcher-application-title-input"
                            name="applicationTitle" placeholder="New Application" type="text"
-                           [(ngModel)]="this.wizardComponent.summary.applicationTitle"
+                           [(ngModel)]="this.wizardComponent.summary.projectName"
                            (keyup.enter)="$event.target.blur();">
                   </div>
                 </div>
                 <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-4 control-label">Maven Artifact</label>
+                  <label class="col-xs-4 control-label">Maven Artifact</label>
                   <div class="col-xs-8 f8launcher-project-summary-data-field">
-                    <span>d4.345</span>
+                    <span>{{this.wizardComponent.summary?.mavenArtifact}}</span>
                   </div>
                 </div>
                 <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-4 control-label">Version</label>
+                  <label class="col-xs-4 control-label">Version</label>
                   <div class="col-xs-8 f8launcher-project-summary-data-field">
-                    <span>124.644</span>
+                    <input class="f8launcher-project-summary-data-field_input f8launcher-application-title-input"
+                           name="version" placeholder="Version Number" type="text"
+                           [(ngModel)]="this.wizardComponent.summary.projectVersion"
+                           (keyup.enter)="$event.target.blur();">
                   </div>
                 </div>
                 <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-4 control-label">Group ID</label>
+                  <label class="col-xs-4 control-label">Group ID</label>
                   <div class="col-xs-8 f8launcher-project-summary-data-field">
-                    <span>124-644</span>
+                    <input class="f8launcher-project-summary-data-field_input f8launcher-application-title-input"
+                           name="groupId" placeholder="Group ID" type="text"
+                           [(ngModel)]="this.wizardComponent.summary.groupId"
+                           (keyup.enter)="$event.target.blur();">
                   </div>
                 </div>
                 <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-4 control-label">Space Path</label>
+                  <label class="col-xs-4 control-label">Space Path</label>
                   <div class="col-xs-8 f8launcher-project-summary-data-field">
-                    <span>/myspace</span>
+                    <input class="f8launcher-project-summary-data-field_input f8launcher-application-title-input"
+                           name="spacePath" placeholder="Space Path" type="text"
+                           [(ngModel)]="this.wizardComponent.summary.spacePath"
+                           (keyup.enter)="$event.target.blur();">
                   </div>
                 </div>
               </form>
@@ -154,41 +174,58 @@
       </div>
       <div class="col-xs-12 col-md-6">
         <div class="card-pf card-pf--small">
-          <div class="card-pf-heading">
-            <h2 class="card-pf-title">
-              GitHub
-            </h2>
-          </div>
-          <div class="card-pf-body card-column">
-            <div class="card-column-70">
-              <form class="form-horizontal">
-                <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-5 control-label">Authorized Account</label>
-                  <div class="col-xs-6 f8launcher-project-summary-data-field">
-                    <div class="f8launcher-project-summary-data-field-account">
-                      <i class="fa fa-ban fa-2x"></i>
-                      <span class="f8launcher-project-summary-data-field-account-username">bdellasc</span>
+          <div *ngIf="wizardComponent.summary?.githubLogin === undefined;
+                      then showNoGitHubTemplate else showGitHubTemplate"></div>
+          <ng-template #showNoGitHubTemplate>
+            <div class="card-pf-body f8launcher-project-summary-data-unavailable">
+              <span class="fa fa-ban"></span>
+              <h2>No Authorized Git Provider</h2>
+              <p>To proceed with setting up this application, there must be a selected Git provider</p>
+              <button class="btn btn-default btn-lg f8launcher-authorize-account"
+                      (click)="navToStep('GitProvider')">Authorize Git Provider</button>
+            </div>
+          </ng-template>
+          <ng-template #showGitHubTemplate>
+            <div class="card-pf-heading">
+              <h2 class="card-pf-title">
+                GitHub
+              </h2>
+            </div>
+            <div class="card-pf-body card-column">
+              <div class="card-column-70">
+                <form class="form-horizontal">
+                  <div class="form-group f8launcher-project-summary-data-form-group">
+                    <label class="col-xs-5 control-label">Authorized Account</label>
+                    <div class="col-xs-6 f8launcher-project-summary-data-field">
+                      <div class="f8launcher-project-summary-data-field-account">
+                        <img height="30px" width="30px" [src]="wizardComponent.summary.githubAvatar"
+                             *ngIf="wizardComponent.summary?.githubAvatar !== undefined">
+                        <i class="fa fa-ban fa-2x" *ngIf="this.wizardComponent.summary?.githubAvatar === undefined"></i>
+                        <span class="f8launcher-project-summary-data-field-account-username">
+                          {{wizardComponent.summary?.githubLogin}}
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
-                <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-5 control-label">Organization</label>
-                  <div class="col-xs-6 f8launcher-project-summary-data-field">
-                    <span>Name_of_Org_repo</span>
+                  <div class="form-group f8launcher-project-summary-data-form-group">
+                    <label class="col-xs-5 control-label">Organization</label>
+                    <div class="col-xs-6 f8launcher-project-summary-data-field">
+                      <span>{{wizardComponent.summary?.githubOrg}}</span>
+                    </div>
                   </div>
-                </div>
-                <div class="form-group f8launcher-project-summary-data-form-group">
-                  <label for="projectName" class="col-xs-5 control-label">Repository</label>
-                  <div class="col-xs-6 f8launcher-project-summary-data-field">
-                    <span>Name_of_Org_repo_1</span>
+                  <div class="form-group f8launcher-project-summary-data-form-group">
+                    <label class="col-xs-5 control-label">Repository</label>
+                    <div class="col-xs-6 f8launcher-project-summary-data-field">
+                      <span>{{wizardComponent.summary?.githubRepo}}</span>
+                    </div>
                   </div>
-                </div>
-              </form>
+                </form>
+              </div>
+              <div class="card-column-30">
+                <i class="fa fa-github git-provider-icon"></i>
+              </div>
             </div>
-            <div class="card-column-30">
-              <i class="fa fa-github git-provider-icon"></i>
-            </div>
-          </div>
+          </ng-template>
         </div>
       </div>
     </div>
@@ -197,7 +234,7 @@
     <div class="f8launcher-continue">
       <button class="btn btn-primary"
               [disabled]="stepCompleted !== true"
-              (click)="navToNextStep()">Set Up</button> or press <b>ENTER</b>
+              (click)="setup()">Set Up</button> or press <b>ENTER</b>
     </div>
   </div>
 </section>

--- a/src/app/launcher/project-summary-step/project-summary-step.component.less
+++ b/src/app/launcher/project-summary-step/project-summary-step.component.less
@@ -33,5 +33,11 @@
         color: @color-pf-black-900;
       }
     }
+    &-unavailable {
+      text-align: center;
+      .fa-ban {
+        font-size: 60px;
+      }
+    }
   }
 }

--- a/src/app/launcher/project-summary-step/project-summary-step.component.ts
+++ b/src/app/launcher/project-summary-step/project-summary-step.component.ts
@@ -2,10 +2,14 @@ import {
   Component,
   Host,
   Input,
+  OnDestroy,
   OnInit,
   ViewEncapsulation
 } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
 
+import { ProjectSummaryService } from '../service/project-summary.service';
+import { Selection } from '../model/selection.model';
 import { WizardComponent } from '../wizard.component';
 import { WizardStep } from '../wizard-step';
 
@@ -15,17 +19,40 @@ import { WizardStep } from '../wizard-step';
   templateUrl: './project-summary-step.component.html',
   styleUrls: ['./project-summary-step.component.less']
 })
-export class ProjectSummaryStepComponent extends WizardStep implements OnInit {
+export class ProjectSummaryStepComponent extends WizardStep implements OnDestroy, OnInit {
   @Input() id: string;
 
-  private _summary: any;
+  private subscriptions: Subscription[] = [];
 
-  constructor(@Host() public wizardComponent: WizardComponent) {
+  constructor(@Host() public wizardComponent: WizardComponent,
+              private projectSummaryService: ProjectSummaryService) {
     super();
   }
 
   ngOnInit() {
+    this.subscriptions.push(this.projectSummaryService.getMavenArtifact().subscribe((val) => {
+      this.wizardComponent.summary.mavenArtifact = val;
+    }));
+    this.subscriptions.push(this.projectSummaryService.getGroupId().subscribe((val) => {
+      this.wizardComponent.summary.groupId = val;
+    }));
+    this.subscriptions.push(this.projectSummaryService.getProjectName().subscribe((val) => {
+      this.wizardComponent.summary.projectName = val;
+    }));
+    this.subscriptions.push(this.projectSummaryService.getProjectVersion().subscribe((val) => {
+      this.wizardComponent.summary.projectVersion = val;
+    }));
+    this.subscriptions.push(this.projectSummaryService.getSpacePath().subscribe((val) => {
+      this.wizardComponent.summary.spacePath = val;
+    }));
     this.wizardComponent.addStep(this);
+    this.restoreSummary();
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach((sub) => {
+      sub.unsubscribe();
+    });
   }
 
   // Accessors
@@ -46,28 +73,65 @@ export class ProjectSummaryStepComponent extends WizardStep implements OnInit {
     return completed;
   }
 
-  /**
-   * Returns summary
-   *
-   * @returns {string} The summary
-   */
-  get summary(): string {
-    return this._summary;
-  }
-
-  /**
-   * Set the summary
-   *
-   * @param {string} val The summary
-   */
-  set summary(val: string) {
-    this._summary = val;
-  }
-
   // Steps
 
+  /**
+   * Navigate to next step
+   */
   navToNextStep(): void {
     this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
     this.wizardComponent.navToNextStep();
+  }
+
+  /**
+   * Navigate to step
+   *
+   * @param {string} id The step ID
+   */
+  navToStep(id: string) {
+    this.wizardComponent.stepIndicator.navToStep(id);
+  }
+
+  /**
+   * Set up this application
+   */
+  setup(): void {
+    this.subscriptions.push(this.projectSummaryService.setup(this.wizardComponent.summary).subscribe((val) => {
+      if (val === true) {
+        this.navToNextStep();
+      }
+    }));
+  }
+
+  // Todo: When do we verify?
+
+  /**
+   * Verify and set up this application
+   */
+  verify(): void {
+    this.subscriptions.push(this.projectSummaryService.verify(this.wizardComponent.summary).subscribe((val) => {
+      if (val === true) {
+        this.setup();
+      }
+    }));
+  }
+
+  // Private
+
+  private initCompleted(): void {
+    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
+  }
+
+  // Restore mission & runtime summary
+  private restoreSummary(): void {
+    let selection: Selection = this.wizardComponent.selectionParams;
+    if (selection === undefined) {
+      return;
+    }
+    this.wizardComponent.summary.groupId = selection.groupId;
+    this.wizardComponent.summary.projectName = selection.projectName;
+    this.wizardComponent.summary.projectVersion = selection.projectVersion;
+    this.wizardComponent.summary.spacePath = selection.spacePath;
+    this.initCompleted();
   }
 }

--- a/src/app/launcher/release-strategy-step/release-strategy-step.component.ts
+++ b/src/app/launcher/release-strategy-step/release-strategy-step.component.ts
@@ -43,6 +43,7 @@ export class ReleaseStrategyStepComponent extends WizardStep implements OnInit, 
   private _pipelineId: string;
   private sortConfig: SortConfig;
   private currentSortField: SortField;
+
   private subscriptions: Subscription[] = [];
 
   constructor(@Host() public wizardComponent: WizardComponent,
@@ -83,8 +84,8 @@ export class ReleaseStrategyStepComponent extends WizardStep implements OnInit, 
           this._pipelines[i].expanded = true;
         }
       }
+      this.restoreSummary();
     }));
-    this.restoreSummary();
   }
 
   ngOnDestroy() {
@@ -94,15 +95,6 @@ export class ReleaseStrategyStepComponent extends WizardStep implements OnInit, 
   }
 
   // Accessors
-
-  /**
-   * Returns indicator that step is completed
-   *
-   * @returns {boolean} True if step is completed
-   */
-  get stepCompleted(): boolean {
-    return (this.wizardComponent.summary.pipeline !== undefined);
-  }
 
   /**
    * Returns a list of pipelines to display
@@ -129,6 +121,15 @@ export class ReleaseStrategyStepComponent extends WizardStep implements OnInit, 
    */
   set pipelineId(val: string) {
     this._pipelineId = val;
+  }
+
+  /**
+   * Returns indicator that step is completed
+   *
+   * @returns {boolean} True if step is completed
+   */
+  get stepCompleted(): boolean {
+    return (this.wizardComponent.summary.pipeline !== undefined);
   }
 
   // Filter
@@ -193,15 +194,19 @@ export class ReleaseStrategyStepComponent extends WizardStep implements OnInit, 
   // Steps
 
   navToNextStep(): void {
-    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
     this.wizardComponent.navToNextStep();
   }
 
   updatePipelineSelection(pipeline: Pipeline): void {
     this.wizardComponent.summary.pipeline = pipeline;
+    this.initCompleted();
   }
 
   // Private
+
+  private initCompleted(): void {
+    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
+  }
 
   // Restore mission & runtime summary
   private restoreSummary(): void {
@@ -210,6 +215,12 @@ export class ReleaseStrategyStepComponent extends WizardStep implements OnInit, 
       return;
     }
     this.pipelineId = selection.pipelineId;
+    for (let i = 0; i < this.pipelines.length; i++) {
+      if (this.pipelineId === this.pipelines[i].pipelineId) {
+        this.wizardComponent.summary.pipeline = this.pipelines[i];
+      }
+    }
+    this.initCompleted();
   }
 
   private toggleExpanded(pipeline: Pipeline) {

--- a/src/app/launcher/service/gitprovider.service.ts
+++ b/src/app/launcher/service/gitprovider.service.ts
@@ -12,12 +12,11 @@ export abstract class GitProviderService {
   abstract authorize(redirectUrl: string): void;
 
   /**
-   * Get GitHub repo details for given full name
+   * Get GitHub organizations
    *
-   * @param fullName The GitHub full name (e.g., fabric8-services/fabric8-wit)
-   * @returns {Observable<any>}
+   * @returns {Observable<any[]>}
    */
-  abstract getRepoDetailsByFullName(fullName: string): Observable<any>;
+  abstract getOrgs(): Observable<any[]>;
 
   /**
    * Get authenticate GitHub user
@@ -25,11 +24,4 @@ export abstract class GitProviderService {
    * @returns {Observable<any>}
    */
   abstract getUser(): Observable<any>;
-
-  /**
-   * Get authentication token
-   *
-   * @returns {Observable<any>}
-   */
-  abstract getToken(): Observable<any>;
 }

--- a/src/app/launcher/service/project-summary.service.ts
+++ b/src/app/launcher/service/project-summary.service.ts
@@ -1,0 +1,59 @@
+import { Observable } from 'rxjs';
+
+import { Summary } from '../model/summary.model';
+
+/**
+ * Abstract project summary service provided to ensure consumer implements this pattern
+ */
+export abstract class ProjectSummaryService {
+  /**
+   * Get Maven artifact
+   *
+   * @returns {Observable<string>}
+   */
+  abstract getMavenArtifact(): Observable<string>;
+
+  /**
+   * Get group ID
+   *
+   * @returns {Observable<string>}
+   */
+  abstract getGroupId(): Observable<string>;
+
+  /**
+   * Get project name
+   *
+   * @returns {Observable<string>}
+   */
+  abstract getProjectName(): Observable<string>;
+
+  /**
+   * Get project version
+   *
+   * @returns {Observable<string>}
+   */
+  abstract getProjectVersion(): Observable<string>;
+
+  /**
+   * Get space path
+   *
+   * @returns {Observable<string>}
+   */
+  abstract getSpacePath(): Observable<string>;
+
+  /**
+   * Set up the project for the given summary
+   *
+   * @param {Summary} summary The project summary
+   * @returns {Observable<boolean>}
+   */
+  abstract setup(summary: Summary): Observable<boolean>;
+
+  /**
+   * Verify the project for the given summary
+   *
+   * @param {Summary} summary The project summary
+   * @returns {Observable<boolean>}
+   */
+  abstract verify(summary: Summary): Observable<boolean>;
+}

--- a/src/app/launcher/step-indicator/step-indicator.component.html
+++ b/src/app/launcher/step-indicator/step-indicator.component.html
@@ -1,7 +1,7 @@
 <div class="f8launcher-application-title">
   <input class="f8launcher-application-title-input"
          name="applicationTitle" placeholder="New Application" type="text"
-         [(ngModel)]="wizardComponent.summary.applicationTitle"
+         [(ngModel)]="wizardComponent.summary.projectName"
          (keyup.enter)="$event.target.blur();">
 </div>
 <div class="f8launcher-vertical-bar"

--- a/src/app/launcher/step-indicator/step-indicator.component.ts
+++ b/src/app/launcher/step-indicator/step-indicator.component.ts
@@ -66,6 +66,6 @@ export class StepIndicatorComponent implements OnInit {
     if (selection === undefined) {
       return;
     }
-    this.wizardComponent.summary.applicationTitle = selection.applicationTitle;
+    this.wizardComponent.summary.projectName = selection.projectName;
   }
 }

--- a/src/app/launcher/targetenvironment-step/target-environment-step.component.html
+++ b/src/app/launcher/targetenvironment-step/target-environment-step.component.html
@@ -15,7 +15,7 @@
           <div class="card-pf card-pf-view card-pf-view-select card-pf-view-single-select card-pf--medium">
             <div class="card-title">
               <input name="target-environment" type="radio"
-                     [(ngModel)]="targetEnvironment"
+                     [(ngModel)]="wizardComponent.summary.targetEnvironment"
                      [value]="'os'"
                      (ngModelChange)="updateTargetEnvSelection()">
               <h2 class="card-pf-title--title">Code Locally, Build and Deploy Online</h2>
@@ -49,7 +49,7 @@
           <div class="card-pf card-pf-view card-pf-view-select card-pf-view-single-select card-pf--medium">
             <div class="card-title">
               <input name="target-environment" type="radio"
-                     [(ngModel)]="targetEnvironment"
+                     [(ngModel)]="wizardComponent.summary.targetEnvironment"
                      [value]="'zip'"
                      (ngModelChange)="updateTargetEnvSelection()">
               <h2 class="card-pf-title--title">Build &amp; Run Locally</h2>

--- a/src/app/launcher/targetenvironment-step/target-environment-step.component.ts
+++ b/src/app/launcher/targetenvironment-step/target-environment-step.component.ts
@@ -18,8 +18,6 @@ import { WizardStep } from '../wizard-step';
 export class TargetEnvironmentStepComponent extends WizardStep {
   @Input() id: string;
 
-  private _targetEnvironment: string;
-
   constructor(@Host() public wizardComponent: WizardComponent) {
     super();
   }
@@ -40,36 +38,21 @@ export class TargetEnvironmentStepComponent extends WizardStep {
     return (this.wizardComponent.summary.targetEnvironment !== undefined);
   }
 
-  /**
-   * Returns target environment
-   *
-   * @returns {string} The target environment
-   */
-  get targetEnvironment(): string {
-    return this._targetEnvironment;
-  }
-
-  /**
-   * Set the target environment
-   *
-   * @param {string} val The target environment
-   */
-  set targetEnvironment(val: string) {
-    this._targetEnvironment = val;
-  }
-
   // Steps
 
   navToNextStep(): void {
-    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
     this.wizardComponent.navToNextStep();
   }
 
   updateTargetEnvSelection(): void {
-    this.wizardComponent.summary.targetEnvironment = this.targetEnvironment;
+    this.initCompleted();
   }
 
   // Private
+
+  private initCompleted(): void {
+    this.wizardComponent.getStep(this.id).completed = this.stepCompleted;
+  }
 
   // Restore mission & runtime summary
   private restoreSummary(): void {
@@ -77,6 +60,7 @@ export class TargetEnvironmentStepComponent extends WizardStep {
     if (selection === undefined) {
       return;
     }
-    this.targetEnvironment = selection.targetEnvironment;
+    this.wizardComponent.summary.targetEnvironment = selection.targetEnvironment;
+    this.initCompleted();
   }
 }

--- a/src/app/launcher/wizard.component.ts
+++ b/src/app/launcher/wizard.component.ts
@@ -61,9 +61,17 @@ export class WizardComponent implements AfterViewInit, OnInit {
    */
   get selection(): Selection {
     let selection = {
+      githubOrg: this._summary.githubOrg,
+      githubRepo: this._summary.githubRepo,
+      groupId: this._summary.groupId,
       missionId: this._summary.mission.missionId,
+      pipelineId: this._summary.pipeline.pipelineId,
+      projectName: this._summary.projectName,
+      projectVersion: this._summary.projectVersion,
       runtimeId: this._summary.runtime.runtimeId,
-      runtimeVersion: this._summary.runtime.version
+      runtimeVersion: this._summary.runtime.version,
+      spacePath: this._summary.spacePath,
+      targetEnvironment: this._summary.targetEnvironment
     } as Selection;
     return selection;
   }

--- a/src/demo/app.module.ts
+++ b/src/demo/app.module.ts
@@ -16,12 +16,14 @@ import { DemoGitProviderService } from './service/demo-gitprovider.service';
 import { DemoMissionRuntimeService } from './service/demo-mission-runtime.service';
 import { DemoPipelineService } from './service/demo-pipeline.service';
 import { DemoProjectProgressService } from './service/demo-project-progress.service';
+import { DemoProjectSummaryService } from './service/demo-project-summary.service';
 import { GitProviderService } from '../app/launcher/launcher.module';
 import {
   LauncherModule,
   MissionRuntimeService,
   PipelineService,
-  ProjectProgressService
+  ProjectProgressService,
+  ProjectSummaryService
 } from '../app/launcher/launcher.module';
 
 @NgModule({
@@ -40,7 +42,8 @@ import {
     { provide: GitProviderService, useClass: DemoGitProviderService},
     { provide: MissionRuntimeService, useClass: DemoMissionRuntimeService },
     { provide: PipelineService, useClass: DemoPipelineService },
-    { provide: ProjectProgressService, useClass: DemoProjectProgressService }
+    { provide: ProjectProgressService, useClass: DemoProjectProgressService },
+    { provide: ProjectSummaryService, useClass: DemoProjectSummaryService }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/demo/service/demo-gitprovider.service.ts
+++ b/src/demo/service/demo-gitprovider.service.ts
@@ -1,45 +1,39 @@
 import { Injectable } from '@angular/core';
-import { Http } from '@angular/http';
 import { Observable } from 'rxjs';
 
 import { GitProviderService } from '../../app/launcher/launcher.module';
 
-// Enable Access-Conrtol-Expose-Headers for CORS to test
+// Enable Access-Conrtol-Expose-Headers for CORS test
 @Injectable()
 export class DemoGitProviderService implements GitProviderService {
-  private static readonly HEADERS = new Headers({
-    'Content-Type': 'application/json',
-    'Accept': 'application/vnd.github.v3+json'
-  });
-
-  private clientId: string = 'a59372e52d3128f59dfb'; // Temp test app
-  private clientSecret: string = 'd78cccc1a3310d06b7b7debe7e9f0df7bcda16a5'; // Temp test app
-  private gitHubUrl: string = 'https://api.github.com';
-  private token: string;
-
-  constructor(private http: Http) {
-  }
-
-  authorize(redirectUrl: string): void {
-    let url = 'https://github.com/login/oauth/authorize?client_id=' + this.clientId +
-      '&redirect_uri=' + encodeURIComponent(redirectUrl);
-    this.redirectToAuth(url);
+  constructor() {
   }
 
   /**
-   * Get GitHub repo details for given full name
+   * Authorize GitHub account
    *
-   * @param fullName The GitHub full name (e.g., fabric8-services/fabric8-wit)
-   * @returns {Observable<any>}
+   * @param {string} redirectUrl The URL to return back to from GitHub
    */
-  getRepoDetailsByFullName(fullName: string): Observable<any> {
-    let url = `${this.gitHubUrl}/repos/${fullName}`;
-    return this.getHeaders()
-      .switchMap(newHeaders => this.http
-        .get(url, { headers: newHeaders }))
-      .map(response => {
-        return response.json();
-      });
+  authorize(redirectUrl: string): void {
+    // let url = 'https://github.com/login/oauth/authorize?client_id=' + this.clientId +
+    //  '&redirect_uri=' + encodeURIComponent(redirectUrl);
+    this.redirectToAuth(redirectUrl);
+  }
+
+  /**
+   * Get GitHub organizations
+   *
+   * @returns {Observable<any[]>}
+   */
+  getOrgs(): Observable<any[]> {
+    // https://api.github.com/users/:username/orgs
+    return Observable.of([{
+      name: 'fabric8-launcher',
+      url: 'https://github.com/fabric8-launcher'
+    }, {
+      name: 'patternfly',
+      url: 'https://github.com/patternfly'
+    }]);
   }
 
   /**
@@ -48,87 +42,15 @@ export class DemoGitProviderService implements GitProviderService {
    * @returns {Observable<any>}
    */
   getUser(): Observable<any> {
-    let url = `${this.gitHubUrl}/user`;
-    return this.getHeaders()
-      .switchMap(newHeaders => this.http
-        .get(url, { headers: newHeaders }))
-      .map(response => {
-        return response.json();
-      });
-  }
-
-  /**
-   * Get authentication token
-   *
-   * @returns {Observable<any>}
-   */
-  getToken(): Observable<any> {
-    if (this.token !== undefined) {
-      return Observable.of(this.token);
-    }
-    let code = this.getRequestParam('code');
-    if (code === null) {
-      return Observable.empty();
-    }
-    let url = 'https://github.com/login/oauth/access_token?' + 'client_id=' +
-      this.clientId + '&client_secret=' + this.clientSecret + '&code=' + code;
-    return this.http.get(url)
-      .map((response) => {
-        let body = response.text();
-        let accessToken = this.getParamFromString('access_token', body);
-        if (accessToken !== null) {
-          this.token = accessToken;
-        }
-        return this.token;
-      });
+    return Observable.of({
+      login: 'bdellasc',
+      avatar_url: 'https://avatars0.githubusercontent.com/u/17882357?s=400&v=4'
+    });
   }
 
   // Private
 
-  // Get GitHub headers for authentified user
-  private getHeaders(): Observable<any> {
-    if (this.token !== undefined) {
-      let newHeaders: any = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/vnd.github.v3+json',
-        'Authorization': `token ${this.token}`
-      };
-      return Observable.of(newHeaders);
-    }
-    return this.getToken().map(token => {
-      let newHeaders: any = {
-        'Content-Type': 'application/json',
-        'Accept': 'application/vnd.github.v3+json',
-        'Authorization': `token ${token}`
-      };
-      return newHeaders;
-    });
-  }
-
-  /**
-   * Helper to retrieve request parameters
-   *
-   * @param name The request parameter to retrieve
-   * @returns {any} The request parameter value or null
-   */
-  private getRequestParam(name: string): string {
-    let param = (new RegExp('[?&]' + encodeURIComponent(name) + '=([^&]*)')).exec(window.location.search);
-    if (param !== null) {
-      return decodeURIComponent(param[1]);
-    }
-    return null;
-  }
-
-  private getParamFromString(name: string, val: string): string {
-    let param = (new RegExp(encodeURIComponent(name) + '=([^&]*)')).exec(val);
-    if (param !== null) {
-      return decodeURIComponent(param[1]);
-    }
-    return null;
-  }
-
   private redirectToAuth(url: string) {
-    console.log('DemoGitProviderService.redirectToAuth: ' + url);
     window.location.href = url;
   }
 }

--- a/src/demo/service/demo-mission-runtime.service.ts
+++ b/src/demo/service/demo-mission-runtime.service.ts
@@ -18,42 +18,50 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
         'suggested': true,
         'title': 'Basic Application',
         'description': 'Brief description of the Basic Application mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': 'Crud',
         'title': 'Crud',
         'description': 'Brief description of the Crud mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': 'CircuitBreaker',
         'title': 'Circuit Breaker',
         'description': 'Brief description of the Circuit Breaker mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': 'ExternalizedConfiguration',
         'title': 'Externalized Configuration',
         'description': 'Brief description of the Externalized Configuration mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': 'RESTAPILevel0',
         'title': 'REST API Level 0',
         'description': 'Brief description of the REST API Level 0 mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': '1',
         'title': 'Another Item 1',
         'description': 'Brief description of the another item mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': '2',
         'title': 'Another Item 2',
         'description': 'Brief description of the another item mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'missionId': '3',
         'title': 'Another Item 3',
         'description': 'Brief description of the another item mission and what it does.',
-        'supportedRuntimes': []
+        'supportedRuntimes': [],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }] as Mission[]);
     return missions;
   }
@@ -64,31 +72,35 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
         'runtimeId': 'SpringBoot',
         'title': 'Spring Boot',
         'description': 'Brief description of the technology...',
-        'logo': '../../../assets/images/spring-boot-logo.png',
+        'logo': '/assets/images/spring-boot-logo.png',
         'supportedMissions': [],
-        'versions': ['v1.0.0', 'v1.0.1', 'v2.0.1']
+        'versions': ['v1.0.0', 'v1.0.1', 'v2.0.1'],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'runtimeId': 'Nodejs',
         'title': 'Node.js',
         'disabled': true,
         'description': 'Brief description of the technology...',
-        'logo': '../../../assets/images/nodejs-logo.png',
+        'logo': '/assets/images/nodejs-logo.png',
         'supportedMissions': [],
-        'versions': ['v1.0.0', 'v3.0.1', 'v3.0.2']
+        'versions': ['v1.0.0', 'v3.0.1', 'v3.0.2'],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'runtimeId': 'Eclipse Vert.x',
         'title': 'Eclipse Vert.x',
         'description': 'Brief description of the technology...',
-        'logo': '../../../assets/images/vertx.svg',
+        'logo': '/assets/images/vertx.svg',
         'supportedMissions': [],
-        'versions': ['v1.0.0']
+        'versions': ['v1.0.0'],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }, {
         'runtimeId': 'Wildfly Swarm',
         'title': 'Wildfly Swarm',
         'description': 'Brief description of the technology...',
-        'logo': '../../../assets/images/wildfly-swarm.png',
+        'logo': '/assets/images/wildfly-swarm.png',
         'supportedMissions': [],
-        'versions': ['v1.0.0', 'v2.0.0', 'v2.0.1']
+        'versions': ['v1.0.0', 'v2.0.0', 'v2.0.1'],
+        'url': 'https://github.com/fabric8-launcher/ngx-launcher'
       }
     ] as Runtime[]);
     return runtimes;

--- a/src/demo/service/demo-project-summary.service.ts
+++ b/src/demo/service/demo-project-summary.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { Subscription } from 'rxjs/Subscription';
+
+import { ProjectSummaryService } from '../../app/launcher/launcher.module';
+import { Summary } from '../../app/launcher/launcher.module';
+
+@Injectable()
+export class DemoProjectSummaryService implements ProjectSummaryService {
+  constructor() {
+  }
+
+  /**
+   * Get Maven artifact
+   *
+   * @returns {Observable<string>}
+   */
+  getMavenArtifact(): Observable<string> {
+    return Observable.of('d4.345');
+  }
+
+  /**
+   * Get group ID
+   *
+   * @returns {Observable<string>}
+   */
+  getGroupId(): Observable<string> {
+    return Observable.of('124-644');
+  }
+
+  /**
+   * Get project name
+   *
+   * @returns {Observable<string>}
+   */
+  getProjectName(): Observable<string> {
+    return Observable.of('App_test_1');
+  }
+
+  /**
+   * Get project version
+   *
+   * @returns {Observable<string>}
+   */
+   getProjectVersion(): Observable<string> {
+    return Observable.of('124.554');
+  }
+
+  /**
+   * Get space path
+   *
+   * @returns {Observable<any>}
+   */
+  getSpacePath(): Observable<string> {
+    return Observable.of('/myspace');
+  }
+
+  /**
+   * Set up the project for the given summary
+   *
+   * @param {Summary} summary The project summary
+   * @returns {Observable<boolean>}
+   */
+  setup(summary: Summary): Observable<boolean> {
+    return Observable.of(true);
+  }
+
+  /**
+   * Verify the project for the given summary
+   *
+   * @param {Summary} summary The project summary
+   * @returns {Observable<boolean>}
+   */
+  verify(summary: Summary): Observable<boolean> {
+    return Observable.of(true);
+  }
+}


### PR DESCRIPTION
- Removed hard coded HTML for pipeline, mission, runtime, github values from summary page.
- User can now inline edit application info; group ID, app name, app version, & space path.
- Dynamically show navigation buttons for incomplete pipeline and git provider steps.
- Save and restore values properly upon page refresh due to git authorization.
- Once expected selections are made, users are no longer forced to click Ok button in order to proceed to next step.
- Simplified up git provider in order to show correct state in summary page.
- Fixed broken images (demo/webpack) shown for summary, mission/runtime pages.