### PR TITLE
app-launcher: rearranged card order for mission and runtime screen

### DIFF
--- a/src/app/launcher/mission-runtime-step/mission-runtime-step.component.html
+++ b/src/app/launcher/mission-runtime-step/mission-runtime-step.component.html
@@ -4,7 +4,7 @@
     <div class="container-fluid">
       <h1 snInViewport (onInViewportChange)="wizardComponent.onInViewportChange($event, 'MissionRuntime')"
           [debounce]="500">
-        Select Runtime &amp; Mission
+        Select Mission & Runtime
         <button class="btn btn-default btn-lg pull-right" type="button"
                 [disabled]="selectionAvailable !== true"
                 (click)="resetSelections()">
@@ -12,13 +12,52 @@
         </button>
       </h1>
       <p>
-        Start by selecting a runtime or a mission.  Valid pairings are narrowed based on your initial selection.
+        Start by selecting a mission or a runtime.  Valid pairings are narrowed based on your initial selection.
       </p>
     </div>
   </div>
   <div>
     <div class="container-fluid container-cards-pf">
       <div class="row row-cards-pf">
+        <div class="col-xs-12 col-md-6">
+          <div class="card-pf card-pf--large">
+            <div class="card-pf-heading">
+              <h2 class="card-pf-title">
+                Select Mission
+              </h2>
+            </div>
+            <div class="card-pf-body">
+              <div class="list-group list-view-pf" *ngFor="let mission of missions">
+                <div class="list-group-item list-view-pf-stacked list-view-pf-top-align"
+                     [ngClass]="{'disabled': isMissionDisabled(mission) === true}">
+                  <div class="f8launcher-tag-featured" *ngIf="mission.suggested === true">
+                    Suggested Mission <i class="pficon pficon-info"></i>
+                  </div>
+                  <div class="list-view-pf-checkbox">
+                    <input type="radio" name="mission"
+                           [disabled]="isMissionDisabled(mission) === true"
+                           [(ngModel)]="missionId"
+                           [value]="mission.id"
+                           (ngModelChange)="updateMissionSelection(mission)">
+                  </div>
+                  <div class="list-view-pf-main-info">
+                    <div class="list-view-pf-body">
+                      <div class="list-view-pf-description">
+                        <div class="list-group-item-heading">
+                          {{mission.name}}
+                        </div>
+                        <div class="list-group-item-text">
+                          {{mission.description}}
+                          <a [href]="mission.url" target="_blank" *ngIf="mission.url !== undefined"> more</a>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="col-xs-12 col-md-6">
           <div class="card-pf card-pf--large">
             <div class="card-pf-heading">
@@ -71,45 +110,6 @@
                         <div class="list-group-item-text">
                           {{runtime.description}}
                           <a [href]="runtime.url" target="_blank" *ngIf="runtime.url !== undefined"> more</a>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="col-xs-12 col-md-6">
-          <div class="card-pf card-pf--large">
-            <div class="card-pf-heading">
-              <h2 class="card-pf-title">
-                Select Mission
-              </h2>
-            </div>
-            <div class="card-pf-body">
-              <div class="list-group list-view-pf" *ngFor="let mission of missions">
-                <div class="list-group-item list-view-pf-stacked list-view-pf-top-align"
-                     [ngClass]="{'disabled': isMissionDisabled(mission) === true}">
-                  <div class="f8launcher-tag-featured" *ngIf="mission.suggested === true">
-                    Suggested Mission <i class="pficon pficon-info"></i>
-                  </div>
-                  <div class="list-view-pf-checkbox">
-                    <input type="radio" name="mission"
-                           [disabled]="isMissionDisabled(mission) === true"
-                           [(ngModel)]="missionId"
-                           [value]="mission.id"
-                           (ngModelChange)="updateMissionSelection(mission)">
-                  </div>
-                  <div class="list-view-pf-main-info">
-                    <div class="list-view-pf-body">
-                      <div class="list-view-pf-description">
-                        <div class="list-group-item-heading">
-                          {{mission.name}}
-                        </div>
-                        <div class="list-group-item-text">
-                          {{mission.description}}
-                          <a [href]="mission.url" target="_blank" *ngIf="mission.url !== undefined"> more</a>
                         </div>
                       </div>
                     </div>

--- a/src/app/launcher/wizard.component.html
+++ b/src/app/launcher/wizard.component.html
@@ -12,7 +12,7 @@
         <f8launcher-missionruntime-step #missionRuntimeStep
             [id]="'MissionRuntime'"
             [styleClass]="'mission-runtime'"
-            [title]="'Select Runtime & Mission'">
+            [title]="'Select Mission & Runtime'">
         </f8launcher-missionruntime-step>
 <!-- Place holder for Dependency Checker
         <f8launcher-dependencychecker-step
@@ -44,7 +44,7 @@
           [hidden]="!(missionRuntimeStep.completed === true && targetEnvStep.completed === true)"
           [id]="'ProjectSummary'"
           [styleClass]="'project-summary'"
-        [title]="'Confirm Application Summary & Setup'">
+          [title]="'Confirm Application Summary & Setup'">
         </f8launcher-projectsummary-step>
       </div>
     </ng-template>

--- a/src/demo/service/demo-mission-runtime.service.ts
+++ b/src/demo/service/demo-mission-runtime.service.ts
@@ -13,6 +13,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
   getMissions(): Observable<Mission[]> {
     let missions = Observable.of([{
       'id': 'crud',
+      'description': 'Brief description of the mission...',
       'name': 'CRUD',
       'suggested': false,
       'runtimes': [
@@ -24,6 +25,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
     },
       {
         'id': 'circuit-breaker',
+        'description': 'Brief description of the mission...',
         'name': 'Circuit Breaker',
         'suggested': false,
         'runtimes': [
@@ -36,6 +38,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
       },
       {
         'id': 'configmap',
+        'description': 'Brief description of the mission...',
         'name': 'Externalized Configuration',
         'suggested': false,
         'runtimes': [
@@ -47,6 +50,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
       },
       {
         'id': 'health-check',
+        'description': 'Brief description of the mission...',
         'name': 'Health Check',
         'suggested': false,
         'runtimes': [
@@ -58,6 +62,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
       },
       {
         'id': 'rest-http',
+        'description': 'Brief description of the mission...',
         'name': 'REST API Level 0',
         'suggested': false,
         'runtimes': [
@@ -69,6 +74,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
       },
       {
         'id': 'rest-http-secured',
+        'description': 'Brief description of the mission...',
         'name': 'Secured',
         'suggested': false,
         'runtimes': [
@@ -197,55 +203,19 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
           },
           {
             'id': 'configmap',
-            'versions': [
-              {
-                'id': 'redhat',
-                'name': '3.4.2.redhat-006 (RHOAR)'
-              },
-              {
-                'id': 'community',
-                'name': '3.5.0.Final (Community)'
-              }
-            ]
+            'versions': []
           },
           {
             'id': 'health-check',
-            'versions': [
-              {
-                'id': 'redhat',
-                'name': '3.4.2.redhat-006 (RHOAR)'
-              },
-              {
-                'id': 'community',
-                'name': '3.5.0.Final (Community)'
-              }
-            ]
+            'versions': []
           },
           {
             'id': 'rest-http',
-            'versions': [
-              {
-                'id': 'redhat',
-                'name': '3.4.2.redhat-006 (RHOAR)'
-              },
-              {
-                'id': 'community',
-                'name': '3.5.0.Final (Community)'
-              }
-            ]
+            'versions': []
           },
           {
             'id': 'rest-http-secured',
-            'versions': [
-              {
-                'id': 'redhat',
-                'name': '3.4.2.redhat-006 (RHOAR)'
-              },
-              {
-                'id': 'community',
-                'name': '3.5.0.Final (Community)'
-              }
-            ]
+            'versions': []
           }
         ],
         'url': 'https://github.com/fabric8-launcher/ngx-launcher'
@@ -261,16 +231,7 @@ export class DemoMissionRuntimeService implements MissionRuntimeService {
         'missions': [
           {
             'id': 'crud',
-            'versions': [
-              {
-                'id': 'community',
-                'name': '1.5.8.RELEASE (Community)'
-              },
-              {
-                'id': 'redhat',
-                'name': '1.5.8.RELEASE (RHOAR)'
-              }
-            ]
+            'versions': []
           },
           {
             'id': 'circuit-breaker',


### PR DESCRIPTION
Rearranged card order for the mission and runtime screen, per UXD feedback.
Added missing (mock) description text for missions.