### PR TITLE
app-launcher: modified ngx-forge package module to use index.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ var watchDist = 'dist-watch';
 function copyToDist(srcArr) {
   return gulp.src(srcArr)
     .pipe(gulp.dest(function (file) {
-      return libraryDist + file.base.slice(__dirname.length + 'src/'.length); // save directly to dist
+      return libraryDist + file.base.slice(__dirname.length); // save directly to dist
     }));
 }
 
@@ -61,7 +61,7 @@ function transpileLESS(src, debug) {
     }))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest(function (file) {
-      return libraryDist + file.base.slice(__dirname.length + 'src/'.length);
+      return libraryDist + file.base.slice(__dirname.length);
     }));
     combined.on('error', console.error.bind(console));
     return combined;
@@ -108,7 +108,7 @@ gulp.task('stylelint', function lintLessTask() {
 // FIXME: why do we need that?
 // replaces templateURL/styleURL with require statements in js.
 gulp.task('post-transpile', ['transpile'], function () {
-  return gulp.src(['dist/app/**/*.js'])
+  return gulp.src(['dist/src/**/*.js'])
     .pipe(replace(/templateUrl:\s/g, "template: require("))
     .pipe(replace(/\.html',/g, ".html'),"))
     .pipe(replace(/styleUrls: \[/g, "styles: [require("))
@@ -140,6 +140,13 @@ gulp.task('copy-html', function () {
   ]);
 });
 
+// copies images to libraryDist.
+gulp.task('copy-images', function () {
+  return copyToDist([
+    'src/assets/images/**/*.*'
+  ]);
+});
+
 // require transpile to finish before copying the css
 gulp.task('copy-css', ['transpile'], function () {
   return copyToDist([
@@ -163,6 +170,7 @@ gulp.task('build:library',
 [
   'post-transpile',
   'copy-html',
+  'copy-images',
   'bundle',
   'copy-static-assets'
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -341,20 +341,6 @@
           "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
           "dev": true
         },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "lodash.defaults": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -841,14 +827,6 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
-    "asciidoctor.js": {
-      "version": "1.5.6-preview.4",
-      "resolved": "https://registry.npmjs.org/asciidoctor.js/-/asciidoctor.js-1.5.6-preview.4.tgz",
-      "integrity": "sha512-UucbsMLe3a2sRdNJ25IkzSDm0z0km67D2hRcD7+EHokrD8J+ThJpRdSH/7CE+4GmQ7p+1ajnMFmLsmkr3GIfUQ==",
-      "requires": {
-        "opal-runtime": "0.11.0-integration8"
-      }
-    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -1130,7 +1108,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -1334,6 +1313,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -1873,20 +1853,6 @@
         "rimraf": "2.5.4"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "rimraf": {
           "version": "2.5.4",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
@@ -1938,22 +1904,14 @@
       "dev": true
     },
     "cloneable-readable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.1.tgz",
+      "integrity": "sha512-DNNEq6JdqBFPzS29TaoqZFPNLn5Xn3XyPFqLIhyBT8Xou4lHQEWzD6FinXoJUfhIfWX3aE1JkRa3cbWCHFbt1g==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        }
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.5"
       }
     },
     "co": {
@@ -2151,7 +2109,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.5.0",
@@ -2364,6 +2323,19 @@
         "node-dir": "0.1.17"
       },
       "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "loader-utils": {
           "version": "0.2.17",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
@@ -2390,22 +2362,6 @@
         "mkdirp": "0.5.1",
         "noms": "0.0.0",
         "through2": "2.0.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "core-js": {
@@ -5426,10 +5382,12 @@
       "dev": true
     },
     "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
+        "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "minimatch": "3.0.4",
@@ -5621,22 +5579,6 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "globjoin": {
@@ -5927,7 +5869,7 @@
             "clone": "2.1.1",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
+            "cloneable-readable": "1.1.1",
             "remove-trailing-separator": "1.1.0",
             "replace-ext": "1.0.0"
           }
@@ -7179,6 +7121,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "1.4.0",
         "wrappy": "1.0.2"
@@ -7187,7 +7130,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -7809,20 +7753,6 @@
         "jasmine-core": "2.99.1"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "jasmine-core": {
           "version": "2.99.1",
           "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.99.1.tgz",
@@ -8013,20 +7943,6 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
           "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
         },
         "lodash": {
           "version": "3.10.1",
@@ -8352,20 +8268,6 @@
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
             "supports-color": "5.3.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
           }
         },
         "globby": {
@@ -9164,7 +9066,7 @@
         "is-promise": "2.1.0",
         "lru-queue": "0.1.0",
         "next-tick": "1.0.0",
-        "timers-ext": "0.1.2"
+        "timers-ext": "0.1.3"
       }
     },
     "memory-fs": {
@@ -9275,6 +9177,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -9502,9 +9405,12 @@
       "dev": true
     },
     "ngx-bootstrap": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.3.tgz",
-      "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.8.0.tgz",
+      "integrity": "sha512-y4+9cQkCAZ8C2iHfGC9PMu6tqHqDPyZN0ejz4fDwWljAUtxqXqwUgPKAnebkckdLw/EFmozgvf27ouVqhDA+CA==",
+      "requires": {
+        "moment": "2.18.1"
+      }
     },
     "no-case": {
       "version": "2.3.2",
@@ -10032,16 +9938,9 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
-      }
-    },
-    "opal-runtime": {
-      "version": "0.11.0-integration8",
-      "resolved": "https://registry.npmjs.org/opal-runtime/-/opal-runtime-0.11.0-integration8.tgz",
-      "integrity": "sha1-hELdyMZiecbNAEv3pzCnhkYgLbI=",
-      "requires": {
-        "glob": "6.0.4"
       }
     },
     "opener": {
@@ -10475,7 +10374,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -10743,16 +10643,6 @@
         "lodash": "4.17.5",
         "ngx-bootstrap": "1.8.0",
         "patternfly": "3.30.1"
-      },
-      "dependencies": {
-        "ngx-bootstrap": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.8.0.tgz",
-          "integrity": "sha512-y4+9cQkCAZ8C2iHfGC9PMu6tqHqDPyZN0ejz4fDwWljAUtxqXqwUgPKAnebkckdLw/EFmozgvf27ouVqhDA+CA==",
-          "requires": {
-            "moment": "2.18.1"
-          }
-        }
       }
     },
     "pause-stream": {
@@ -11714,20 +11604,6 @@
             "supports-color": "5.3.0"
           }
         },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -12142,22 +12018,6 @@
       "requires": {
         "glob": "7.1.2",
         "postcss-import": "10.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "postcss-property-lookup": {
@@ -12795,20 +12655,6 @@
             "has-ansi": "2.0.0",
             "strip-ansi": "3.0.1",
             "supports-color": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
           }
         },
         "q": {
@@ -13775,22 +13621,6 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "ripemd160": {
@@ -14283,22 +14113,6 @@
         "glob": "7.1.2",
         "interpret": "1.1.0",
         "rechoir": "0.6.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
       }
     },
     "sigmund": {
@@ -15286,20 +15100,6 @@
           "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
           "dev": true
         },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
         "globby": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
@@ -15637,9 +15437,9 @@
       }
     },
     "timers-ext": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.2.tgz",
-      "integrity": "sha1-YcxHp2wavTGV8UUn+XjViulMUgQ=",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.3.tgz",
+      "integrity": "sha512-2iKErlS+NnEr0aQVQS91/mjsqCDO4OFl+5c5RDNtP+acQJTySvNSdbiSbmBD0t2RbErirF2Vq7x5YPQOSva77Q==",
       "dev": true,
       "requires": {
         "es5-ext": "0.10.39",
@@ -16083,20 +15883,6 @@
                 "path-is-absolute": "1.0.1"
               }
             }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -17636,7 +17422,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ngx-forge",
-  "version": "0.0.56-development",
+  "version": "0.0.57-development",
   "description": "Forge services for Angular v2 and up",
-  "main": "bundles/ngx-forge.js",
-  "module": "bundles/ngx-forge.js",
+  "main": "index.js",
+  "module": "index.js",
   "typings": "index.d.ts",
   "scripts": {
     "build": "npm run remove-dist && npm run build:library",

--- a/src/app/components/input/input.component.ts
+++ b/src/app/components/input/input.component.ts
@@ -11,8 +11,8 @@ import { Subject } from 'rxjs/Subject';
 
 @Component({
   selector: 'la-input',
-  templateUrl: 'input.component.html',
-  styleUrls: ['input.component.less'],
+  templateUrl: './input.component.html',
+  styleUrls: ['./input.component.less'],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/src/app/components/project-select/project-select.component.ts
+++ b/src/app/components/project-select/project-select.component.ts
@@ -12,8 +12,8 @@ const PROJECTSELECT_VALUE_ACCESSOR: any = {
 @Component({
   selector: 'ob-project-select',
   providers: [PROJECTSELECT_VALUE_ACCESSOR],
-  templateUrl: 'project-select.component.html',
-  styleUrls: ['project-select.component.less']
+  templateUrl: './project-select.component.html',
+  styleUrls: ['./project-select.component.less']
 })
 export class ProjectSelect extends DefaultValueAccessor {
   @Input() input: Field;

--- a/src/app/launcher/cancel-overlay/cancel-overlay.component.ts
+++ b/src/app/launcher/cancel-overlay/cancel-overlay.component.ts
@@ -9,8 +9,8 @@ import { LauncherComponent } from '../launcher.component';
 
 @Component({
   selector: 'f8launcher-cancel-overlay',
-  styleUrls: ['./cancel-overlay.component.less'],
-  templateUrl: './cancel-overlay.component.html'
+  templateUrl: './cancel-overlay.component.html',
+  styleUrls: ['./cancel-overlay.component.less']
 })
 export class CancelOverlayComponent implements OnInit {
 

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -121,7 +121,7 @@
                        *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
                     <span class="f8launcher-tags-label" container="body" triggers="click"
                           outsideClick="true"
-                          popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production." triggers="click"
+                          popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                           *ngIf="launcherComponent.summary?.pipeline?.suggested === true">
                       Suggested <i class="pficon pficon-info"></i>
                     </span>

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
@@ -29,7 +29,7 @@
                         *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
                       <span class="f8launcher-tags-label" container="body" triggers="click"
                             outsideClick="true"
-                            popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production." triggers="click"
+                            popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                             *ngIf="pipeline.suggested === true">
                         Suggested <i class="pficon pficon-info"></i>
                       </span>

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -41,7 +41,7 @@
                        *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
                     <span class="f8launcher-tags-label" container="body" triggers="click"
                           outsideClick="true"
-                          popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production." triggers="click"
+                          popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                           *ngIf="launcherComponent.summary?.pipeline?.suggested === true">
                       Suggested <i class="pficon pficon-info"></i>
                     </span>

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
@@ -33,7 +33,7 @@
                          *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
                       <span class="f8launcher-tags-label" container="body" triggers="click"
                             outsideClick="true"
-                            popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production." triggers="click"
+                            popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                             *ngIf="pipeline.suggested === true">
                         Suggested <i class="pficon pficon-info"></i>
                       </span>


### PR DESCRIPTION
Fixes: https://github.com/fabric8-launcher/ngx-launcher/issues/93
Tested via npm link with fabric8-ui.

Benefits:
- While the ngx-forge.js bundle is still available, these changes help fabric8-ui build performance because Angular isn’t resolving duplicates.
- Allows fabric8-ui to install its own dependencies instead of packages being duplicated by the ngx-forge.js bundle.
- Eliminates the ‘multiple mobx instances’ error seen with fabric8-ui unit tests, since certain dependencies are duplicated by the ngx-forge.js bundle.

Changes:

- Copied HTML and CSS to the correct dist/src/app directories instead of dist/app
- Copied missing images directory to dist/src/assets
- Modified package.json module to use index.js
- Fixed components with missing HTML and CSS paths
- Moved styleUrls after templateUrl so grunt can properly rename files from “.less” to “.css”
- Removed duplicate 'trigger' attributes to avoid fabric8-ui's linter attr-no-duplication errors
- bumped package version number for next release