### PR TITLE
Adding validation on application name input field

### DIFF
--- a/src/app/launcher/step-indicator/step-indicator.component.html
+++ b/src/app/launcher/step-indicator/step-indicator.component.html
@@ -2,8 +2,11 @@
   <input class="f8launcher-application-text-field_input"
          name="applicationTitle" placeholder="New Application" type="text"
          [(ngModel)]="launcherComponent.summary.dependencyCheck.projectName"
-         (keyup.enter)="$event.target.blur();">
+         (keyup.enter)="$event.target.blur();" 
+         pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+         #check="ngModel" minlength="4">
 </div>
+<div [hidden]="!check.hasError('pattern') && !check.hasError('minlength')" class="error-msg">Invalid Application Name</div>
 <div class="f8launcher-vertical-bar"
      [ngClass]="{'in-progress': inProgress === true}">
   <a class="f8launcher-vertical-bar_steps--item {{step.styleClass}}" href="javascript:void(0)"

--- a/src/app/launcher/step-indicator/step-indicator.component.less
+++ b/src/app/launcher/step-indicator/step-indicator.component.less
@@ -1,6 +1,10 @@
 @import (reference) '../../../assets/stylesheets/shared/main.less';
 
 .f8launcher {
+  .error-msg {
+    color: rgb(199, 0, 0);
+    padding-left: 10px;
+  }
   &-container {
     &_nav {
       display: -moz-box;

--- a/src/demo/getting-started-osio/getting-started-osio.component.html
+++ b/src/demo/getting-started-osio/getting-started-osio.component.html
@@ -17,7 +17,11 @@
                   </label>
                   <span class="code-imports--step_pencil">
                     <input id="projectName" name="projectName" type="text" class="form-control code-imports--step_input col-sm-5" placeholder="Enter Application Name"
-                      aria-label="Application Name Input" required [(ngModel)]="projectName">
+                      aria-label="Application Name Input" required [(ngModel)]="projectName" 
+                      pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*"
+                      #check="ngModel"
+                      minlength="4">
+                      <div [hidden]="!check.hasError('pattern') && !check.hasError('minlength')" class="error-msg">Invalid Application Name</div>
                   </span>
                   <p class="help-block">
                     Application name must be unique, at least 4 characters long, cannot be more than 65 characters and must contain only letters,

--- a/src/demo/getting-started-osio/getting-started-osio.component.less
+++ b/src/demo/getting-started-osio/getting-started-osio.component.less
@@ -18,6 +18,9 @@ input,
   overflow-y: auto;
   .form-group {
     margin-top: 35px;
+    .error-msg {
+      color: rgb(199, 0, 0)
+    }
   }
   .form-control {
     background-color: transparent;


### PR DESCRIPTION
Fixes: #100 
Application name requires validation:

- Application name must contain only small letters, numbers, hyphens.
- It can not start and end with numbers, hyphens or spaces.
- It should be minimum four characters long.

If the application name doesn't match the above validations request is failing on back-end.

Related Issue: [launcher-backend/issues/181](https://github.com/fabric8-launcher/launcher-backend/issues/181)