### PR TITLE
app-launcher: cleanup empty CSS selectors

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
@@ -32,36 +32,37 @@
               </h2>
             </div>
             <div class="card-pf-body">
-              <div class="list-group list-view-pf"
-                   [ngClass]="{'contribute': isMissionDisabled(mission) === true,
+              <div class="list-group list-view-pf f8launcher-tags"
+                   [ngClass]="{'prerequisite': mission.prerequisite !== undefined,
                                'suggested': mission.suggested === true,
-                               'prerequisite': mission.prerequisite !== undefined}"
+                               'contribute': isMissionDisabled(mission) === true}"
                    *ngFor="let mission of (missions | sortArray: 'suggested': true)">
                 <div class="list-group-item list-view-pf-stacked list-view-pf-top-align"
                      [ngClass]="{'disabled': isMissionDisabled(mission) === true, 'selected-list-item': missionId === mission.id}">
                   <div class="list-group-item-header"
                        *ngIf="mission.prerequisite !== undefined || mission.suggested === true || isMissionDisabled(mission) === true">
                     <div class="f8launcher-tags"
-                         [ngClass]="{'contribute': isMissionDisabled(mission) === true,
-                                     'prerequisite': isMissionDisabled(mission) !== true && mission.prerequisite !== undefined}">
+                         [ngClass]="{'prerequisite': mission.prerequisite !== undefined,
+                                     'suggested': mission.suggested === true,
+                                     'contribute': isMissionDisabled(mission) === true}">
                       <ng-template #missionContributeTemplate>
                         This mission and runtime combination is not currently available, but you can contribute to our
                         <a href='https://appdev.openshift.io/docs/contrib-guide.html#_documentation' target="_blank">library</a>
                         and help us expand these offerings.
                       </ng-template>
-                      <span class="f8launcher-contribute-tag-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label contribute" container="body" triggers="click"
                             outsideClick="true"
                             [popover]="missionContributeTemplate"
                             *ngIf="isMissionDisabled(mission) === true">
                         Contribute <i class="pficon pficon-info"></i>
                       </span>
-                      <span class="f8launcher-suggested-tag-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This mission will get you started with a bare bones working application."
                             *ngIf="mission.suggested === true">
                         Suggested <i class="pficon pficon-info"></i>
                       </span>
-                      <span class="f8launcher-prerequisite-tag-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label prerequisite" container="body" triggers="click"
                             outsideClick="true"
                             popover="{{mission.prerequisite}}"
                             *ngIf="mission.prerequisite !== undefined">
@@ -114,35 +115,37 @@
               </h2>
             </div>
             <div class="card-pf-body">
-              <div class="list-group list-view-pf"
-                   [ngClass]="{'contribute': isRuntimeDisabled(runtime) === true,
+              <div class="list-group list-view-pf f8launcher-tags"
+                   [ngClass]="{'prerequisite': runtime.prerequisite !== undefined,
                                'suggested': runtime.suggested === true,
-                               'prerequisite': runtime.prerequisite !== undefined}"
+                               'contribute': isRuntimeDisabled(runtime) === true}"
                    *ngFor="let runtime of runtimes; let i = index">
                 <div class="list-group-item list-view-pf-stacked list-view-pf-top-align"
                      [ngClass]="{'disabled': isRuntimeDisabled(runtime) === true, 'selected-list-item': runtimeId === runtime.id}">
                   <div class="list-group-item-header"
                        *ngIf="runtime.prerequisite !== undefined || runtime.suggested === true || isRuntimeDisabled(runtime) === true">
                     <div class="f8launcher-tags"
-                         [ngClass]="{'contribute': isRuntimeDisabled(runtime) === true}">
+                         [ngClass]="{'prerequisite': runtime.prerequisite !== undefined,
+                                     'suggested': runtime.suggested === true,
+                                     'contribute': isRuntimeDisabled(runtime) === true}">
                       <ng-template #runtimeContributeTemplate>
                         This mission and runtime combination is not currently available, but you can contribute to our
                         <a href='https://appdev.openshift.io/docs/contrib-guide.html#_documentation' target="_blank">library</a>
                         and help us expand these offerings.
                       </ng-template>
-                      <span class="f8launcher-contribute-tag-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label contribute" container="body" triggers="click"
                             outsideClick="true"
                             [popover]="runtimeContributeTemplate"
                             *ngIf="isRuntimeDisabled(runtime) === true">
                         Contribute <i class="pficon pficon-info"></i>
                       </span>
-                      <span class="f8launcher-suggested-tag-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This runtime will get you started with a bare bones working application."
                             *ngIf="runtime.suggested === true">
                         Suggested <i class="pficon pficon-info"></i>
                       </span>
-                      <span class="f8launcher-prerequisite-tag-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label prerequisite" container="body" triggers="click"
                             outsideClick="true"
                             popover="{{runtime.prerequisite}}"
                             *ngIf="runtime.prerequisite !== undefined">

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.less
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.less
@@ -22,17 +22,6 @@
   .container-cards-pf {
     margin-top: 10px;
   }
-  .list-group {
-    &.contribute {
-      border-top: 1px solid @color-pf-green;
-    }
-    &.prerequisite {
-      border-top: 1px solid @color-pf-orange;
-    }
-    &.suggested {
-      border-top: 1px solid @color-pf-blue;
-    }
-  }
   .list-group-item-header {
     margin-left: 16px;
     margin-right: -16px;

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
@@ -180,7 +180,7 @@ describe('MissionRuntimeStepComponent', () => {
   it('should have the suggested missions tag when mission.suggested field is true', () => {
     element = fixture.nativeElement;
     let missionsSection = element.querySelectorAll('.card-pf-body')[0];
-    let featuredTag = missionsSection.querySelector('.f8launcher-suggested-tag-label');
+    let featuredTag = missionsSection.querySelector('.f8launcher-tags-label.suggested');
     expect(featuredTag).toBeDefined();
   });
 
@@ -189,14 +189,14 @@ describe('MissionRuntimeStepComponent', () => {
     fixture.detectChanges();
     element = fixture.nativeElement;
     let missionsSection = element.querySelectorAll('.card-pf-body')[0];
-    let featuredTag = missionsSection.querySelector('.f8launcher-suggested-tag-label');
+    let featuredTag = missionsSection.querySelector('.f8launcher-tags-label.suggested');
     expect(featuredTag).toBeNull();
   });
 
   it('should have the prerequisite missions tag when mission.prerequisite field is present', () => {
     element = fixture.nativeElement;
     let missionsSection = element.querySelectorAll('.card-pf-body')[0];
-    let featuredTag = missionsSection.querySelector('.f8launcher-prerequisite-tag-label');
+    let featuredTag = missionsSection.querySelector('.f8launcher-tags-label.prerequisite');
     expect(featuredTag).toBeDefined();
   });
 
@@ -205,7 +205,7 @@ describe('MissionRuntimeStepComponent', () => {
     fixture.detectChanges();
     element = fixture.nativeElement;
     let missionsSection = element.querySelectorAll('.card-pf-body')[0];
-    let featuredTag = missionsSection.querySelector('.f8launcher-prerequisite-tag-label');
+    let featuredTag = missionsSection.querySelector('.f8launcher-tags-label.prerequisite');
     expect(featuredTag).toBeNull();
   });
 
@@ -337,7 +337,7 @@ describe('MissionRuntimeStepComponent', () => {
   it('should have the suggested runtimes tag when runtime.suggested field is true', () => {
     element = fixture.nativeElement;
     let runtimesSection = element.querySelectorAll('.card-pf-body')[1];
-    let featuredTag = runtimesSection.querySelector('.f8launcher-suggested-tag-label');
+    let featuredTag = runtimesSection.querySelector('.f8launcher-tags-label.suggested');
     expect(featuredTag).toBeDefined();
   });
 
@@ -346,14 +346,14 @@ describe('MissionRuntimeStepComponent', () => {
     fixture.detectChanges();
     element = fixture.nativeElement;
     let runtimesSection = element.querySelectorAll('.card-pf-body')[1];
-    let featuredTag = runtimesSection.querySelector('.f8launcher-suggested-tag-label');
+    let featuredTag = runtimesSection.querySelector('.f8launcher-tags-label.suggested');
     expect(featuredTag).toBeNull();
   });
 
   it('should have the prerequisite runtimes tag when runtime.prerequisite field is present', () => {
     element = fixture.nativeElement;
     let runtimesSection = element.querySelectorAll('.card-pf-body')[1];
-    let featuredTag = runtimesSection.querySelector('.f8launcher-prerequisite-tag-label');
+    let featuredTag = runtimesSection.querySelector('.f8launcher-tags-label.prerequisite');
     expect(featuredTag).toBeDefined();
   });
 
@@ -362,7 +362,7 @@ describe('MissionRuntimeStepComponent', () => {
     fixture.detectChanges();
     element = fixture.nativeElement;
     let runtimesSection = element.querySelectorAll('.card-pf-body')[1];
-    let featuredTag = runtimesSection.querySelector('.f8launcher-prerequisite-tag-label');
+    let featuredTag = runtimesSection.querySelector('.f8launcher-tags-label.prerequisite');
     expect(featuredTag).toBeNull();
   });
 

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -119,13 +119,13 @@
                 <div class="list-group-item-header">
                   <div class="f8launcher-tags"
                        *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
-                    <span class="f8launcher-tags-label" container="body" triggers="click"
+                    <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                           *ngIf="launcherComponent.summary?.pipeline?.suggested === true">
                       Suggested <i class="pficon pficon-info"></i>
                     </span>
-                    <span class="f8launcher-tags-label" container="body" triggers="click"
+                    <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
                           *ngIf="launcherComponent.summary?.pipeline?.techpreview === true">

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
@@ -27,13 +27,13 @@
                   <div class="list-group-item-header">
                     <div class="f8launcher-tags"
                         *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
-                      <span class="f8launcher-tags-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                             *ngIf="pipeline.suggested === true">
                         Suggested <i class="pficon pficon-info"></i>
                       </span>
-                      <span class="f8launcher-tags-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                             outsideClick="true"
                             popover="Technology Preview"
                             *ngIf="pipeline.techpreview === true">

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.less
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.less
@@ -1,5 +1,4 @@
 @import (reference) '../../../../assets/stylesheets/shared/main.less';
-@import '../../../../assets/stylesheets/shared/_labels.less';
 
 .f8launcher-section-release-strategy {
   .control-label {

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -39,13 +39,13 @@
                 <div class="list-group-item-header">
                   <div class="f8launcher-tags"
                        *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
-                    <span class="f8launcher-tags-label" container="body" triggers="click"
+                    <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                           *ngIf="launcherComponent.summary?.pipeline?.suggested === true">
                       Suggested <i class="pficon pficon-info"></i>
                     </span>
-                    <span class="f8launcher-tags-label" container="body" triggers="click"
+                    <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
                           *ngIf="launcherComponent.summary?.pipeline?.techpreview === true">

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
@@ -31,13 +31,13 @@
                   <div class="list-group-item-header">
                     <div class="f8launcher-tags"
                          *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
-                      <span class="f8launcher-tags-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                             *ngIf="pipeline.suggested === true">
                         Suggested <i class="pficon pficon-info"></i>
                       </span>
-                      <span class="f8launcher-tags-label" container="body" triggers="click"
+                      <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                             outsideClick="true"
                             popover="Technology Preview"
                             *ngIf="pipeline.techpreview === true">

--- a/src/assets/stylesheets/shared/_labels.less
+++ b/src/assets/stylesheets/shared/_labels.less
@@ -5,7 +5,7 @@
   &.prerequisite {
     border-top: 1px solid @color-pf-orange;
   }
-  &.suggested {
+  &.suggested, &.techpreview {
     border-top: 1px solid @color-pf-blue;
   }
   &.contribute {
@@ -28,7 +28,7 @@
     &.prerequisite {
       background-color: @color-pf-orange;
     }
-    &.suggested {
+    &.suggested, &.techpreview {
       background-color: @color-pf-blue;
     }
     &.contribute {

--- a/src/assets/stylesheets/shared/_labels.less
+++ b/src/assets/stylesheets/shared/_labels.less
@@ -1,12 +1,15 @@
 @import (reference) 'main.less';
 
 .f8launcher-tags {
-  border-top: 1px solid @color-pf-blue;
-  &.contribute {
-    border-top: 1px solid @color-pf-green;
-  }
+  /* borders are ordered */
   &.prerequisite {
     border-top: 1px solid @color-pf-orange;
+  }
+  &.suggested {
+    border-top: 1px solid @color-pf-blue;
+  }
+  &.contribute {
+    border-top: 1px solid @color-pf-green;
   }
   &:last-child {
     margin-right: 0;
@@ -14,7 +17,6 @@
   &-label {
     margin-left: 5px;
     padding: 0 10px;
-    background-color: @color-pf-blue;
     color: @color-pf-white;
     cursor: pointer;
     font-size: .9em;
@@ -22,11 +24,15 @@
     i {
       color: @color-pf-white;
     }
-    &.contribute {
-      background-color: @color-pf-green;
-    }
+    /* labels are ordered */
     &.prerequisite {
       background-color: @color-pf-orange;
+    }
+    &.suggested {
+      background-color: @color-pf-blue;
+    }
+    &.contribute {
+      background-color: @color-pf-green;
     }
   }
 }


### PR DESCRIPTION
This addresses an issue with empty/dummy CSS selectors introduced for the mission & runtime unit tests.

Currently, these selectors do not exist:

- f8launcher-contribute-tag-label
- f8launcher-suggested-tag-label
- f8launcher-prerequisite-tag-label