### PR TITLE
app-launcher: update patternfly-ng version to match fabric8-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-forge",
-  "version": "0.0.56-development",
+  "version": "0.0.60-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -105,7 +105,7 @@
       "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
       "dev": true,
       "requires": {
-        "acorn": "5.5.1",
+        "acorn": "5.5.3",
         "css": "2.2.1",
         "normalize-path": "2.1.1",
         "source-map": "0.5.7",
@@ -131,7 +131,7 @@
         "chalk": "2.2.2",
         "enhanced-resolve": "3.4.1",
         "loader-utils": "1.1.0",
-        "magic-string": "0.22.4",
+        "magic-string": "0.22.5",
         "semver": "5.5.0",
         "source-map": "0.5.7",
         "tree-kill": "1.2.0"
@@ -220,6 +220,12 @@
         "github-url-from-git": "1.5.0"
       }
     },
+    "@swimlane/ngx-datatable": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-datatable/-/ngx-datatable-11.2.0.tgz",
+      "integrity": "sha512-QlD45YEUwOz6fu7neTtIGBAoV0owY0J9Jkpc2xViXHThWJeW7+mRhg4XRyKm8nvVDuUJZH+7huzAW1lQKN+iYg==",
+      "optional": true
+    },
     "@thisissoon/angular-inviewport": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@thisissoon/angular-inviewport/-/angular-inviewport-1.3.2.tgz",
@@ -231,7 +237,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101"
+        "@types/node": "6.0.102"
       }
     },
     "@types/handlebars": {
@@ -253,9 +259,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.104",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.104.tgz",
-      "integrity": "sha512-ufQcVg4daO8xQ5kopxRHanqFdL4AI7ondQkV+2f+7mz3gvp0LkBx2zBRC6hfs3T87mzQFmf5Fck7Fi145Ul6NQ==",
+      "version": "4.14.105",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.105.tgz",
+      "integrity": "sha512-LB5PKR4QNoDrgcl4H8JdhBMp9wHWp0OATkU9EHzuXKiutRwbvsyYmqPUaMSWmdCycJoKHtdAWh47/zSe/GZ1yA==",
       "dev": true
     },
     "@types/marked": {
@@ -271,9 +277,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.101",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
-      "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+      "version": "6.0.102",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.102.tgz",
+      "integrity": "sha512-EhNufyBoC1Kqaj+XMHGzi6mPUC8wVABOMTPE5XaSJc49LIVvXsyrV1HYMAPTUViT7E4wLUB38OdDmb+HshjGmA==",
       "dev": true
     },
     "@types/q": {
@@ -294,7 +300,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101"
+        "@types/node": "6.0.102"
       }
     },
     "abbrev": {
@@ -329,7 +335,7 @@
         "lodash.partialright": "4.2.1",
         "lodash.pick": "4.4.0",
         "lodash.uniq": "4.5.0",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "semver": "5.5.0",
         "uglify-js": "2.8.29",
         "when": "3.7.8"
@@ -361,9 +367,9 @@
       }
     },
     "acorn": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.1.tgz",
-      "integrity": "sha512-D/KGiCpM/VOtTMDS+wfjywEth926WUrArrzYov4N4SI7t+3y8747dPpCmmAvrm/Z3ygqMHnyPxvYYO0yTdn/nQ==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -469,22 +475,14 @@
       "integrity": "sha512-OvDq5755VeLwKyl3halgvW3FyQoiR5I+SlvbjfBDTAJ2KmhdpDXTu+dAJ0VoaNtWKuihyVZtNy2wp/r4c9Co7w=="
     },
     "angular-tree-component": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/angular-tree-component/-/angular-tree-component-6.1.0.tgz",
-      "integrity": "sha1-nZprKKaIHCByzWMGtVIpV56JQHE=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/angular-tree-component/-/angular-tree-component-7.0.2.tgz",
+      "integrity": "sha512-jSS3Ffhz86bXfOjCMcOEX8HorL1x8kUY03k6NG/a0X7U3LIgaHJeSU0zUGqF2RUoFsWLFvIaVmrrp6FWITYEcw==",
       "optional": true,
       "requires": {
-        "lodash": "4.17.4",
-        "mobx": "3.6.1",
-        "mobx-angular": "2.1.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "optional": true
-        }
+        "lodash": "4.17.5",
+        "mobx": "3.6.2",
+        "mobx-angular": "2.2.0"
       }
     },
     "angular2-template-loader": {
@@ -892,6 +890,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "atoa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atoa/-/atoa-1.0.0.tgz",
+      "integrity": "sha1-DMDpGkgOc4+SPrwQNnZHF3mzSkk=",
+      "optional": true
+    },
     "atob": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
@@ -905,7 +909,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000813",
+        "caniuse-db": "1.0.30000815",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -918,7 +922,7 @@
       "integrity": "sha1-PfGSuRpihfeVymXmOq0RT7tE9xA=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "enhanced-resolve": "3.4.1",
         "loader-utils": "1.1.0",
         "lodash": "4.17.5",
@@ -1071,7 +1075,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.3",
+        "invariant": "2.2.4",
         "lodash": "4.17.5"
       }
     },
@@ -1333,7 +1337,7 @@
         "isobject": "3.0.1",
         "kind-of": "6.0.2",
         "repeat-element": "1.1.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "snapdragon-node": "2.1.1",
         "split-string": "3.1.0",
         "to-regex": "3.0.2"
@@ -1447,8 +1451,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000813",
-        "electron-to-chromium": "1.3.36"
+        "caniuse-db": "1.0.30000815",
+        "electron-to-chromium": "1.3.39"
       }
     },
     "buffer": {
@@ -1458,7 +1462,7 @@
       "dev": true,
       "requires": {
         "base64-js": "1.2.3",
-        "ieee754": "1.1.8",
+        "ieee754": "1.1.10",
         "isarray": "1.0.0"
       }
     },
@@ -1557,21 +1561,21 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000813",
+        "caniuse-db": "1.0.30000815",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000813",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000813.tgz",
-      "integrity": "sha1-4KHGA/iICteHsqNWUrJzPzKl4po=",
+      "version": "1.0.30000815",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000815.tgz",
+      "integrity": "sha1-DiGPoTPQ0HHIhqoEG0NSWMx0aJE=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000813",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000813.tgz",
-      "integrity": "sha512-A8ITSmH5SFdMFdC704ggjg+x2z5PzQmVlG8tavwnfvbC33Q1UYrj0+G+Xm0SNAnd4He36fwUE/KEWytOEchw+A==",
+      "version": "1.0.30000815",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000815.tgz",
+      "integrity": "sha512-PGSOPK6gFe5fWd+eD0u2bG0aOsN1qC4B1E66tl3jOsIoKkTIcBYAc2+O6AeNzKW8RsFykWgnhkTlfOyuTzgI9A==",
       "dev": true
     },
     "caseless": {
@@ -1594,14 +1598,6 @@
       "requires": {
         "align-text": "0.1.4",
         "lazy-cache": "1.0.4"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true
-        }
       }
     },
     "chalk": {
@@ -1686,9 +1682,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
-      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
     },
     "cipher-base": {
@@ -1904,9 +1900,9 @@
       "dev": true
     },
     "cloneable-readable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.1.tgz",
-      "integrity": "sha512-DNNEq6JdqBFPzS29TaoqZFPNLn5Xn3XyPFqLIhyBT8Xou4lHQEWzD6FinXoJUfhIfWX3aE1JkRa3cbWCHFbt1g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -2020,9 +2016,9 @@
       }
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+      "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
       "dev": true
     },
     "combine-lists": {
@@ -2081,7 +2077,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -2228,6 +2224,16 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
+    },
+    "contra": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/contra/-/contra-1.9.4.tgz",
+      "integrity": "sha1-9TveQtfltZhcrk2ZqNYQUm3o8o0=",
+      "optional": true,
+      "requires": {
+        "atoa": "1.0.0",
+        "ticky": "1.0.1"
+      }
     },
     "conventional-changelog": {
       "version": "0.0.17",
@@ -2440,7 +2446,7 @@
         "cipher-base": "1.0.4",
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -2454,7 +2460,7 @@
         "inherits": "2.0.3",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
@@ -2463,21 +2469,30 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
           }
         }
+      }
+    },
+    "crossvent": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
+      "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
+      "optional": true,
+      "requires": {
+        "custom-event": "1.0.0"
       }
     },
     "crypt": {
@@ -2755,10 +2770,9 @@
       }
     },
     "custom-event": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.0.tgz",
+      "integrity": "sha1-LkYovhncSyFLXAJjDFlx6BFhgGI="
     },
     "cz-conventional-changelog": {
       "version": "2.0.0",
@@ -2780,7 +2794,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "d3": {
@@ -3073,7 +3087,7 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "1.0.1",
+        "custom-event": "1.0.0",
         "ent": "2.2.0",
         "extend": "3.0.1",
         "void-elements": "2.0.1"
@@ -3135,6 +3149,16 @@
       "dev": true,
       "requires": {
         "is-obj": "1.0.1"
+      }
+    },
+    "dragula": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/dragula/-/dragula-3.7.2.tgz",
+      "integrity": "sha1-SjXJ05gf+sGpScKcpyhQWOhzk84=",
+      "optional": true,
+      "requires": {
+        "contra": "1.9.4",
+        "crossvent": "1.5.4"
       }
     },
     "duplexer": {
@@ -3213,9 +3237,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.36",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.36.tgz",
-      "integrity": "sha1-Dqv3Gp6+qQE/scw1o5DgaGJPJ+g=",
+      "version": "1.3.39",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.39.tgz",
+      "integrity": "sha1-16RpZAnKCZXidQFW2mEsIhr62E0=",
       "dev": true
     },
     "elliptic": {
@@ -3414,13 +3438,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.39",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
-      "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
+      "version": "0.10.41",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
+      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-symbol": "3.1.1",
+        "next-tick": "1.0.0"
       }
     },
     "es6-iterator": {
@@ -3430,7 +3455,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3447,7 +3472,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "es6-templates": {
@@ -3467,7 +3492,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -3546,12 +3571,12 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -3685,7 +3710,7 @@
         "extend-shallow": "2.0.1",
         "posix-character-classes": "0.1.1",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -3827,9 +3852,9 @@
       }
     },
     "express": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
-      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
         "accepts": "1.3.5",
@@ -3844,7 +3869,7 @@
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.1.0",
+        "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
@@ -3855,10 +3880,10 @@
         "qs": "6.5.1",
         "range-parser": "1.2.0",
         "safe-buffer": "5.1.1",
-        "send": "0.16.1",
-        "serve-static": "1.13.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
+        "statuses": "1.4.0",
         "type-is": "1.6.16",
         "utils-merge": "1.0.1",
         "vary": "1.1.2"
@@ -3874,6 +3899,21 @@
             "negotiator": "0.6.1"
           }
         },
+        "finalhandler": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.4.0",
+            "unpipe": "1.0.0"
+          }
+        },
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
@@ -3884,12 +3924,6 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
       }
@@ -3933,7 +3967,7 @@
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -4330,7 +4364,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.9.2",
+        "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -5729,7 +5763,7 @@
         "autoprefixer": "7.2.6",
         "fancy-log": "1.3.2",
         "plugin-error": "0.1.2",
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
       },
@@ -5741,10 +5775,10 @@
           "dev": true,
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000813",
+            "caniuse-lite": "1.0.30000815",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
-            "postcss": "6.0.19",
+            "postcss": "6.0.20",
             "postcss-value-parser": "3.3.0"
           }
         },
@@ -5754,8 +5788,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000813",
-            "electron-to-chromium": "1.3.36"
+            "caniuse-lite": "1.0.30000815",
+            "electron-to-chromium": "1.3.39"
           }
         },
         "chalk": {
@@ -5776,9 +5810,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -5869,7 +5903,7 @@
             "clone": "2.1.1",
             "clone-buffer": "1.0.0",
             "clone-stats": "1.0.0",
-            "cloneable-readable": "1.1.1",
+            "cloneable-readable": "1.1.2",
             "remove-trailing-separator": "1.1.0",
             "replace-ext": "1.0.0"
           }
@@ -6274,7 +6308,7 @@
       "requires": {
         "@gulp-sourcemaps/identity-map": "1.0.1",
         "@gulp-sourcemaps/map-sources": "1.0.0",
-        "acorn": "5.5.1",
+        "acorn": "5.5.3",
         "convert-source-map": "1.5.1",
         "css": "2.2.1",
         "debug-fabulous": "1.0.0",
@@ -6656,9 +6690,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
       "dev": true
     },
     "hpack.js": {
@@ -6668,9 +6702,9 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
-        "obuf": "1.1.1",
+        "obuf": "1.1.2",
         "readable-stream": "2.3.5",
-        "wbuf": "1.7.2"
+        "wbuf": "1.7.3"
       }
     },
     "html-comment-regex": {
@@ -6693,25 +6727,25 @@
       "requires": {
         "es6-templates": "0.2.3",
         "fastparse": "1.1.1",
-        "html-minifier": "3.5.10",
+        "html-minifier": "3.5.12",
         "loader-utils": "1.1.0",
         "object-assign": "4.1.1"
       }
     },
     "html-minifier": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.10.tgz",
-      "integrity": "sha512-5c8iAyeIGAiuFhVjJ0qy1lgvyQxxuZgjeOuMnoK/wjEyy8DF3xKUnE9pO+6H7VMir976K6SGlZV8ZEmIOea/Zg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.12.tgz",
+      "integrity": "sha512-+N778qLf0RWBscD0TPGoYdeGNDZ0s76/0pQhY1/409EOudcENkm9IbSkk37RDyPdg/09GVHTKotU4ya93RF1Gg==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.11",
-        "commander": "2.14.1",
+        "commander": "2.15.1",
         "he": "1.1.1",
         "ncname": "1.0.0",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.13"
+        "uglify-js": "3.3.16"
       },
       "dependencies": {
         "clean-css": {
@@ -6724,18 +6758,18 @@
           }
         },
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "uglify-js": {
-          "version": "3.3.13",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.13.tgz",
-          "integrity": "sha512-7rdn/bDOG1ElSTPdh7AI5TCjLv63ZD4k8BBadN3ssIkhlaQL2c0yRxmXCyOYhZK0wZTgGgUSnYQ4CGu+Jos5cA==",
+          "version": "3.3.16",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.16.tgz",
+          "integrity": "sha512-FMh5SRqJRGhv9BbaTffENIpDDQIoPDR8DBraunGORGhySArsXlw9++CN+BWzPBLpoI4RcSnpfGPnilTxWL3Vvg==",
           "dev": true,
           "requires": {
-            "commander": "2.14.1",
+            "commander": "2.15.1",
             "source-map": "0.6.1"
           },
           "dependencies": {
@@ -6762,7 +6796,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "html-minifier": "3.5.10",
+        "html-minifier": "3.5.12",
         "loader-utils": "0.2.17",
         "lodash": "4.17.5",
         "pretty-error": "2.1.1",
@@ -6830,9 +6864,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
       "dev": true
     },
     "http-proxy": {
@@ -6982,7 +7016,7 @@
       "requires": {
         "assert-plus": "0.2.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.1"
       }
     },
     "https-browserify": {
@@ -7060,9 +7094,9 @@
       "dev": true
     },
     "ieee754": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz",
+      "integrity": "sha512-byWFX8OyW/qeVxcY21r6Ncxl0ZYHgnf0cPup2h34eHXrCJbOp7IuqnJ4Q0omfyWl6Z++BTI6bByf31pZt7iRLg==",
       "dev": true
     },
     "ignore": {
@@ -7146,9 +7180,9 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
@@ -7261,7 +7295,7 @@
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.2"
+        "ci-info": "1.1.3"
       }
     },
     "is-data-descriptor": {
@@ -7696,7 +7730,7 @@
       "dev": true,
       "requires": {
         "convert-source-map": "1.5.1",
-        "istanbul-lib-instrument": "1.9.2",
+        "istanbul-lib-instrument": "1.10.1",
         "loader-utils": "0.2.17",
         "object-assign": "4.1.1"
       },
@@ -7722,15 +7756,15 @@
       }
     },
     "istanbul-lib-coverage": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz",
-      "integrity": "sha512-tZYA0v5A7qBSsOzcebJJ/z3lk3oSzH62puG78DbBA1+zupipX2CakDyiPV3pOb8He+jBwVimuwB0dTnh38hX0w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+      "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz",
-      "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+      "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
       "dev": true,
       "requires": {
         "babel-generator": "6.26.1",
@@ -7738,7 +7772,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.2",
+        "istanbul-lib-coverage": "1.2.0",
         "semver": "5.5.0"
       }
     },
@@ -7912,7 +7946,7 @@
         "bluebird": "3.5.1",
         "body-parser": "1.18.2",
         "chokidar": "1.7.0",
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "combine-lists": "1.0.1",
         "connect": "3.6.6",
         "core-js": "2.4.1",
@@ -7968,7 +8002,7 @@
       "integrity": "sha1-rmw8WKMTodALRRZMRVubhs4X+WA=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "karma-coverage": {
@@ -8178,13 +8212,10 @@
       "dev": true
     },
     "lazy-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-      "dev": true,
-      "requires": {
-        "set-getter": "0.1.0"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
@@ -8251,7 +8282,7 @@
         "lodash.merge": "4.6.1",
         "lodash.sortby": "4.7.0",
         "minimatch": "3.0.4",
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-less": "1.1.3",
         "postcss-selector-parser": "3.1.1",
         "postcss-values-parser": "1.4.0",
@@ -8297,9 +8328,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -8367,7 +8398,7 @@
         "is-plain-object": "2.0.4",
         "object.map": "1.0.1",
         "rechoir": "0.6.2",
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "load-json-file": {
@@ -8880,7 +8911,7 @@
       "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "0.10.41"
       }
     },
     "ltcdr": {
@@ -8896,9 +8927,9 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
-      "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
         "vlq": "0.2.3"
@@ -9060,13 +9091,13 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "es6-weak-map": "2.0.2",
         "event-emitter": "0.3.5",
         "is-promise": "2.1.0",
         "lru-queue": "0.1.0",
         "next-tick": "1.0.0",
-        "timers-ext": "0.1.3"
+        "timers-ext": "0.1.5"
       }
     },
     "memory-fs": {
@@ -9126,7 +9157,7 @@
         "nanomatch": "1.2.9",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       }
     },
@@ -9227,15 +9258,15 @@
       }
     },
     "mobx": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-3.6.1.tgz",
-      "integrity": "sha1-rmOo8A4UhadA0Pka4val9o4wO+o=",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-3.6.2.tgz",
+      "integrity": "sha512-Dq3boJFLpZEvuh5a/MbHLUIyN9XobKWIb0dBfkNOJffNkE3vtuY0C9kSDVpfH8BB0BPkVw8g22qCv7d05LEhKg==",
       "optional": true
     },
     "mobx-angular": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mobx-angular/-/mobx-angular-2.1.1.tgz",
-      "integrity": "sha1-1eNlOayyABht1aEXCAa0d2uai4g=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mobx-angular/-/mobx-angular-2.2.0.tgz",
+      "integrity": "sha512-wQdRuKFWpjWSxUWon1dSBRw5VnuIkAGI3hBx1IgKxuMgQWUb08Et6h55utdgRmAua+xhaUUTD8dKuki1ezf/yA==",
       "optional": true
     },
     "mocha": {
@@ -9312,11 +9343,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -9333,9 +9359,9 @@
       }
     },
     "nan": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
       "dev": true,
       "optional": true
     },
@@ -9355,14 +9381,14 @@
         "kind-of": "6.0.2",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       }
     },
     "natives": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.2.tgz",
+      "integrity": "sha512-5bRASydE1gu6zPOenLN043++J8xj1Ob7ArkfdYO3JN4DF5rDmG7bMoiybkTyD+GnXQEMixVeDHMzuqm6kpBmiA==",
       "dev": true
     },
     "ncname": {
@@ -9398,6 +9424,15 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ng2-dragula": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ng2-dragula/-/ng2-dragula-1.5.0.tgz",
+      "integrity": "sha512-uSVq66Rv+ZhDLBGYCGZ7mTaseP7rvYJOijiQZlzfy8dxL614Sw7rhtnLqvK8nqa3tI/wVv8CEGZaZkMnWJokwQ==",
+      "optional": true,
+      "requires": {
+        "dragula": "3.7.2"
+      }
+    },
     "ngast": {
       "version": "0.0.15",
       "resolved": "https://registry.npmjs.org/ngast/-/ngast-0.0.15.tgz",
@@ -9405,12 +9440,9 @@
       "dev": true
     },
     "ngx-bootstrap": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.8.0.tgz",
-      "integrity": "sha512-y4+9cQkCAZ8C2iHfGC9PMu6tqHqDPyZN0ejz4fDwWljAUtxqXqwUgPKAnebkckdLw/EFmozgvf27ouVqhDA+CA==",
-      "requires": {
-        "moment": "2.18.1"
-      }
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-1.9.3.tgz",
+      "integrity": "sha512-beoKQGJEFwdg0ctIpGb+vx4PTPkyqHrA5tBAEbnUn7ZlTjjfA6533QYGv3qVoKPDNkkHmLA3lRjWKxEMYepCdg=="
     },
     "no-case": {
       "version": "2.3.2",
@@ -9452,7 +9484,7 @@
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.5",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
+        "stream-http": "2.8.1",
         "string_decoder": "1.0.3",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
@@ -9518,7 +9550,7 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
         "validate-npm-package-license": "3.0.3"
@@ -9563,7 +9595,7 @@
       "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.6.0",
         "semver": "5.5.0"
       }
     },
@@ -9914,9 +9946,9 @@
       }
     },
     "obuf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
-      "integrity": "sha1-EEEktsYCxnlogaBCVB0220OlJk4=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
     "on-finished": {
@@ -10634,14 +10666,16 @@
       }
     },
     "patternfly-ng": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/patternfly-ng/-/patternfly-ng-2.0.5.tgz",
-      "integrity": "sha1-46/1EAloW4hqzW3iE1tvmxDvig8=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/patternfly-ng/-/patternfly-ng-3.1.3.tgz",
+      "integrity": "sha1-MIEbrEHW6C7kD2JuA+PzocKGGCE=",
       "requires": {
-        "angular-tree-component": "6.1.0",
+        "@swimlane/ngx-datatable": "11.2.0",
+        "angular-tree-component": "7.0.2",
         "c3": "0.4.21",
         "lodash": "4.17.5",
-        "ngx-bootstrap": "1.8.0",
+        "ng2-dragula": "1.5.0",
+        "ngx-bootstrap": "1.9.3",
         "patternfly": "3.30.1"
       }
     },
@@ -10664,7 +10698,7 @@
         "create-hmac": "1.1.6",
         "ripemd160": "2.0.1",
         "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
@@ -10722,9 +10756,9 @@
           }
         },
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "fs-extra": {
@@ -10745,7 +10779,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.14.1",
+            "commander": "2.15.1",
             "is-my-json-valid": "2.17.2",
             "pinkie-promise": "2.0.1"
           }
@@ -11003,7 +11037,7 @@
       "dev": true,
       "requires": {
         "css-color-function": "1.3.3",
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-message-helpers": "2.0.0",
         "postcss-value-parser": "3.3.0"
       },
@@ -11026,9 +11060,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11080,7 +11114,7 @@
       "integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11101,9 +11135,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11135,7 +11169,7 @@
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11156,9 +11190,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11189,7 +11223,7 @@
       "integrity": "sha1-eBOC+UxS5yfvXKR3bqKt9JphE4I=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-selector-matches": "3.0.1"
       },
       "dependencies": {
@@ -11211,9 +11245,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11321,10 +11355,10 @@
       "dev": true,
       "requires": {
         "object-assign": "4.1.1",
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-value-parser": "3.3.0",
         "read-cache": "1.0.0",
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       },
       "dependencies": {
         "chalk": {
@@ -11345,9 +11379,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11379,7 +11413,7 @@
       "dev": true,
       "requires": {
         "camelcase-css": "1.0.1",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11400,9 +11434,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11442,7 +11476,7 @@
       "integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11463,9 +11497,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11587,7 +11621,7 @@
       "dev": true,
       "requires": {
         "globby": "6.1.0",
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-js": "1.0.1",
         "postcss-simple-vars": "4.1.0",
         "sugarss": "1.0.1"
@@ -11624,9 +11658,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11657,7 +11691,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11678,9 +11712,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11712,7 +11746,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11733,9 +11767,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11767,7 +11801,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11788,9 +11822,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11822,7 +11856,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11843,9 +11877,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11876,7 +11910,7 @@
       "integrity": "sha512-CU7KjbFOZSNrbFwrl8+KJHTj29GjCEhL86kCKyvf+k633fc+FQA6IuhGyPze5e+a4O5d2fP7hDlMOlVDXia1Xg==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-selector-parser": "2.2.3"
       },
       "dependencies": {
@@ -11898,9 +11932,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -11931,7 +11965,7 @@
       "integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -11952,9 +11986,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12070,7 +12104,7 @@
         "chalk": "2.2.2",
         "lodash": "4.17.5",
         "log-symbols": "2.2.0",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "has-flag": {
@@ -12080,9 +12114,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12132,7 +12166,7 @@
       "integrity": "sha1-t1Pv9sfArqXoN1++TN6L+QY/8UI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -12153,9 +12187,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12186,7 +12220,7 @@
       "integrity": "sha512-IFj42Hz2cBHHFvZTqkJqU08JCCM/MZU5/uNkTUZBaBFP2d4C5unw4HyCL52RfCwJb6KoVUD3eoepxMh1dfBFCQ==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -12207,9 +12241,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12241,7 +12275,7 @@
       "dev": true,
       "requires": {
         "balanced-match": "0.4.2",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "balanced-match": {
@@ -12268,9 +12302,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12302,7 +12336,7 @@
       "dev": true,
       "requires": {
         "balanced-match": "0.4.2",
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "balanced-match": {
@@ -12329,9 +12363,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12373,7 +12407,7 @@
       "integrity": "sha512-J/TRomA8EqXhS4VjQJsPCYTFIa9FYN/dkJK/8oZ0BYeVIPx91goqM8T+ljsP57+4bwSEywFOuB7EZ8n1gjjxZw==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -12394,9 +12428,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12478,7 +12512,7 @@
       "integrity": "sha1-f1Z+MxjgbUTI/b+eWEUug1i/S3E=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-advanced-variables": "1.2.2",
         "postcss-atroot": "0.1.3",
         "postcss-color-function": "4.0.1",
@@ -12514,9 +12548,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -12621,7 +12655,7 @@
       "integrity": "sha1-EMTjNlcbKIdbisw64+Th5A736YY=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.101",
+        "@types/node": "6.0.102",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.43",
         "blocking-proxy": "0.0.5",
@@ -12948,7 +12982,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.5.0"
+        "resolve": "1.6.0"
       }
     },
     "redent": {
@@ -13466,9 +13500,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -13765,9 +13799,9 @@
       }
     },
     "run-auto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/run-auto/-/run-auto-2.0.0.tgz",
-      "integrity": "sha1-X0NT9Yrb1rdJJkibTyWeHa1qeNY=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/run-auto/-/run-auto-2.0.1.tgz",
+      "integrity": "sha512-WG5pCNfeKj2BeD844551pKqBVV1AGjula70DZ85Ok4YG83vTWj89dLTu1NcGNRidGQUuMqrPO9GM7fMi+sBcXA==",
       "dev": true,
       "requires": {
         "dezalgo": "1.0.3"
@@ -13784,9 +13818,9 @@
       }
     },
     "run-series": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-      "integrity": "sha1-iac93F51ye+KtjIMChYA1qQRebk=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.6.tgz",
+      "integrity": "sha512-QRWA6On05041DuB1l0YSA2n3o+92QlNZYk57PB+Zqp+HSnUekIDeiWxcWG4wftIWRAGmIUIyZ2PP8rPTO+t5sw==",
       "dev": true
     },
     "rxjs": {
@@ -13833,14 +13867,14 @@
       "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
       "dev": true,
       "requires": {
-        "ajv": "6.2.1",
+        "ajv": "6.3.0",
         "ajv-keywords": "3.1.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-          "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
+          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "1.1.0",
@@ -13900,8 +13934,8 @@
         "npmconf": "2.1.2",
         "npmlog": "4.1.2",
         "require-relative": "0.8.7",
-        "run-auto": "2.0.0",
-        "run-series": "1.1.4",
+        "run-auto": "2.0.1",
+        "run-series": "1.1.6",
         "semver": "5.5.0"
       },
       "dependencies": {
@@ -13932,9 +13966,9 @@
       }
     },
     "send": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -13949,19 +13983,13 @@
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       },
       "dependencies": {
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
           "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
           "dev": true
         }
       }
@@ -14000,15 +14028,15 @@
       }
     },
     "serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.16.1"
+        "send": "0.16.2"
       }
     },
     "set-blocking": {
@@ -14016,15 +14044,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
-    },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -14068,9 +14087,9 @@
       "dev": true
     },
     "sha.js": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-      "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -14149,9 +14168,9 @@
       "dev": true
     },
     "snapdragon": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
         "base": "0.11.2",
@@ -14161,7 +14180,7 @@
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
         "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -14627,10 +14646,10 @@
         "debug": "2.6.9",
         "detect-node": "2.0.3",
         "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
+        "obuf": "1.1.2",
         "readable-stream": "2.3.5",
         "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
+        "wbuf": "1.7.3"
       }
     },
     "specificity": {
@@ -14664,9 +14683,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -14809,9 +14828,9 @@
       "dev": true
     },
     "stream-http": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
-      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -14998,7 +15017,7 @@
         "micromatch": "2.3.11",
         "normalize-selector": "0.2.0",
         "pify": "3.0.0",
-        "postcss": "6.0.19",
+        "postcss": "6.0.20",
         "postcss-html": "0.11.0",
         "postcss-less": "1.1.3",
         "postcss-media-query-parser": "0.2.3",
@@ -15039,10 +15058,10 @@
           "dev": true,
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000813",
+            "caniuse-lite": "1.0.30000815",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
-            "postcss": "6.0.19",
+            "postcss": "6.0.20",
             "postcss-value-parser": "3.3.0"
           }
         },
@@ -15063,8 +15082,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000813",
-            "electron-to-chromium": "1.3.36"
+            "caniuse-lite": "1.0.30000815",
+            "electron-to-chromium": "1.3.39"
           }
         },
         "debug": {
@@ -15172,9 +15191,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -15241,7 +15260,7 @@
       "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.19"
+        "postcss": "6.0.20"
       },
       "dependencies": {
         "chalk": {
@@ -15262,9 +15281,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.19",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.19.tgz",
-          "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
             "chalk": "2.3.2",
@@ -15317,6 +15336,14 @@
         "mkdirp": "0.5.1",
         "sax": "1.2.4",
         "whet.extend": "0.9.9"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        }
       }
     },
     "symbol-observable": {
@@ -15330,7 +15357,7 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.2.1",
+        "ajv": "6.3.0",
         "ajv-keywords": "3.1.0",
         "chalk": "2.2.2",
         "lodash": "4.17.5",
@@ -15339,9 +15366,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
-          "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.3.0.tgz",
+          "integrity": "sha1-FlCkERTvAFdMrBC4Ay2PTBSBLac=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "1.1.0",
@@ -15412,6 +15439,12 @@
         "xtend": "4.0.1"
       }
     },
+    "ticky": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ticky/-/ticky-1.0.1.tgz",
+      "integrity": "sha1-t8+nHnaPHJAAxJe5FRswlHxQ5G0=",
+      "optional": true
+    },
     "tildify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
@@ -15437,12 +15470,12 @@
       }
     },
     "timers-ext": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.3.tgz",
-      "integrity": "sha512-2iKErlS+NnEr0aQVQS91/mjsqCDO4OFl+5c5RDNtP+acQJTySvNSdbiSbmBD0t2RbErirF2Vq7x5YPQOSva77Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.5.tgz",
+      "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.39",
+        "es5-ext": "0.10.41",
         "next-tick": "1.0.0"
       }
     },
@@ -15600,9 +15633,9 @@
           }
         },
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "form-data": {
@@ -15629,7 +15662,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.14.1",
+            "commander": "2.15.1",
             "is-my-json-valid": "2.17.2",
             "pinkie-promise": "2.0.1"
           }
@@ -15845,12 +15878,12 @@
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "colors": "1.2.1",
         "diff": "3.5.0",
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.5.0",
+        "resolve": "1.6.0",
         "semver": "5.5.0",
         "tsutils": "1.9.1"
       },
@@ -15962,7 +15995,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.104",
+        "@types/lodash": "4.14.105",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -16379,82 +16412,12 @@
       }
     },
     "use": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
-      },
-      "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
-        }
+        "kind-of": "6.0.2"
       }
     },
     "user-home": {
@@ -16469,14 +16432,14 @@
       "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
+        "lru-cache": "4.1.2",
         "tmp": "0.0.31"
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -16650,7 +16613,7 @@
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "dev": true,
           "requires": {
-            "natives": "1.1.1"
+            "natives": "1.1.2"
           }
         },
         "isarray": {
@@ -16812,9 +16775,9 @@
       }
     },
     "wbuf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
-      "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
         "minimalistic-assert": "1.0.0"
@@ -17033,9 +16996,9 @@
       "requires": {
         "acorn": "4.0.13",
         "chalk": "1.1.3",
-        "commander": "2.14.1",
+        "commander": "2.15.1",
         "ejs": "2.5.7",
-        "express": "4.16.2",
+        "express": "4.16.3",
         "filesize": "3.6.0",
         "gzip-size": "3.0.0",
         "lodash": "4.17.5",
@@ -17069,9 +17032,9 @@
           }
         },
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "filesize": {
@@ -17095,7 +17058,7 @@
       "dev": true,
       "requires": {
         "blessed": "0.1.81",
-        "commander": "2.14.1",
+        "commander": "2.15.1",
         "cross-spawn": "4.0.2",
         "filesize": "3.6.0",
         "socket.io": "1.7.3",
@@ -17103,9 +17066,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
-          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
         "cross-spawn": {
@@ -17114,7 +17077,7 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.1.2",
             "which": "1.3.0"
           }
         },
@@ -17125,9 +17088,9 @@
           "dev": true
         },
         "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -17158,7 +17121,7 @@
         "chokidar": "1.7.0",
         "compression": "1.7.2",
         "connect-history-api-fallback": "1.5.0",
-        "express": "4.16.2",
+        "express": "4.16.3",
         "html-entities": "1.2.1",
         "http-proxy-middleware": "0.17.4",
         "opn": "4.0.2",
@@ -17301,7 +17264,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.10",
+        "http-parser-js": "0.4.11",
         "websocket-extensions": "0.1.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "angular-2-dropdown-multiselect": "1.6.0",
     "ngx-bootstrap": "1.9.3",
     "patternfly": "3.30.1",
-    "patternfly-ng": "2.0.5",
+    "patternfly-ng": "3.1.3",
     "rxjs": "5.5.2"
   },
   "peerDependencies": {},

--- a/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.spec.ts
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
 import { InViewportModule, WindowRef } from '@thisissoon/angular-inviewport';
 
 import { PopoverModule } from 'ngx-bootstrap';
-import { PipeModule } from 'patternfly-ng';
+import { PipeModule } from 'patternfly-ng/pipe';
 
 import { LauncherComponent } from '../../launcher.component';
 import { LauncherStep } from '../../launcher-step';

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
 import { InViewportModule, WindowRef } from '@thisissoon/angular-inviewport';
 
 import { PopoverModule } from 'ngx-bootstrap';
-import { PipeModule } from 'patternfly-ng';
+import { PipeModule } from 'patternfly-ng/pipe';
 
 import { LauncherComponent } from '../../launcher.component';
 import { LauncherStep } from '../../launcher-step';

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.spec.ts
@@ -13,11 +13,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { Observable } from 'rxjs';
 import { InViewportModule, WindowRef } from '@thisissoon/angular-inviewport';
 
-import {
-  FilterEvent,
-  PipeModule,
-  SortEvent
-} from 'patternfly-ng';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { PipeModule } from 'patternfly-ng/pipe';
+import { SortEvent } from 'patternfly-ng/sort';
 
 import { LauncherComponent } from '../../launcher.component';
 import { LauncherStep } from '../../launcher-step';

--- a/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.ts
+++ b/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.ts
@@ -8,20 +8,23 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
 
 import {
   Filter,
   FilterConfig,
   FilterField,
   FilterEvent,
-  FilterType,
+  FilterType
+} from 'patternfly-ng/filter';
+
+import {
   SortConfig,
   SortField,
-  SortEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+  SortEvent
+} from 'patternfly-ng/sort';
 
-import { Subscription } from 'rxjs/Subscription';
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 import { GitProviderService } from '../../service/git-provider.service';
 import { Selection } from '../../model/selection.model';

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.ts
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.ts
@@ -12,12 +12,16 @@ import {
   FilterConfig,
   FilterField,
   FilterEvent,
-  FilterType,
+  FilterType
+} from 'patternfly-ng/filter';
+
+import {
   SortConfig,
   SortField,
-  SortEvent,
-  ToolbarConfig
-} from 'patternfly-ng';
+  SortEvent
+} from 'patternfly-ng/sort';
+
+import { ToolbarConfig } from 'patternfly-ng/toolbar';
 
 import { PipelineService } from '../../service/pipeline.service';
 import { Pipeline } from '../../model/pipeline.model';

--- a/src/app/launcher/launcher.module.ts
+++ b/src/app/launcher/launcher.module.ts
@@ -4,7 +4,9 @@ import { FormsModule } from '@angular/forms';
 
 import { BsDropdownConfig, BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { PopoverModule } from 'ngx-bootstrap/popover';
-import { PipeModule, ToolbarModule } from 'patternfly-ng';
+
+import { PipeModule } from 'patternfly-ng/pipe';
+import { ToolbarModule } from 'patternfly-ng/toolbar';
 
 // Note: This has to be imported first
 import { StepIndicatorComponent } from './step-indicator/step-indicator.component';

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -13,3 +13,4 @@ import 'rxjs';
 // import PatternFly CSS
 import '../node_modules/patternfly/dist/css/patternfly.min.css';
 import '../node_modules/patternfly/dist/css/patternfly-additions.min.css';
+import '../node_modules/patternfly-ng/dist/css/patternfly-ng.min.css';


### PR DESCRIPTION
Updated the patternfly-ng package version to match what's used in fabric8-ui.

Also taking advantage of the new patternfly-ng modules so we only import what we need in the UI.