### PR TITLE
removes the dropdown from runtimes as the version are currently singular all the time.

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
@@ -173,7 +173,7 @@
                       <div class="list-view-pf-description">
                         <div class="list-group-item-heading">
                           {{runtime.name}}
-                          <div class="dropdown" dropdown>
+                          <div *ngIf="launcherComponent?.flow !== 'osio'" class="dropdown" dropdown>
                             <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle
                                     [disabled]="isRuntimeDisabled(runtime) === true">
                               {{runtime.version?.name}}


### PR DESCRIPTION
With this PR, dropdowns will no longer be seen in runtimes section of the new launcher flow (OSIO flow)

Tracks https://github.com/openshiftio/openshift.io/issues/2937