### PR TITLE
remove the card-pf--small class from pipelines card in case there are pipelines

### DIFF
--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -89,7 +89,7 @@
   <div class="container-fluid container-cards-pf" *ngIf="launcherComponent.summary?.targetEnvironment === 'os' && launcherComponent.flow !== 'launch'">
     <div class="row row-cards-pf">
       <div class="col-xs-12">
-        <div class="card-pf card-pf--small">
+        <div class="card-pf" [ngClass]="{'card-pf--small': launcherComponent.summary?.pipeline === undefined}">
           <div *ngIf="launcherComponent.summary?.pipeline === undefined;
                       then showNoPipelineTemplate else showPipelineTemplate"></div>
           <ng-template #showNoPipelineTemplate>


### PR DESCRIPTION
Tracks: https://github.com/openshiftio/openshift.io/issues/2936

@mindreeper2420 Currently, in the Project summary screen, we have pipelines card and they are collapsed by default.

That shows a lot of empty space. 
~~This PR handles that by making it expanded by default and removing the option of toggling.~~

~~The reason for this is as this is the Summary screen, it would be good to show the whole information. Please let me know about the change.~~

Based on feedback from Brian in the issue linked, 
In case there are pipelines, the class 'card-pf--small' gets removed so that the height gets adjusted to the content's height.

Toggling feature is available.