### PR TITLE
fix(ux): changes the styles of tags

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
@@ -35,7 +35,7 @@
               </p>
             </div>
             <div class="card-pf-body">
-              <div class="list-group list-view-pf f8launcher-tags"
+              <div class="list-group list-view-pf"
                    [ngClass]="{'prerequisite': mission.prerequisite !== undefined,
                                'suggested': mission.suggested === true,
                                'contribute': isMissionDisabled(mission) === true}"
@@ -121,7 +121,7 @@
               </p>
             </div>
             <div class="card-pf-body">
-              <div class="list-group list-view-pf f8launcher-tags"
+              <div class="list-group list-view-pf"
                    [ngClass]="{'prerequisite': runtime.prerequisite !== undefined,
                                'suggested': runtime.suggested === true,
                                'contribute': isRuntimeDisabled(runtime) === true}"

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -116,14 +116,37 @@
             <div class="card-pf-body">
               <div class="list-group-item"
                    [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true}">
-                <div class="list-group-item-header">
-                  <div class="f8launcher-tags"
-                       *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
+                <div class="group" [ngClass]="{'with-tag': launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline.techpreview === true}">
+                  <div class="list-view-pf-expand">
+                          <span class="fa"
+                                [ngClass]="{'fa-angle-down': launcherComponent.summary?.pipeline?.expanded === true,
+                                            'fa-angle-right': launcherComponent.summary?.pipeline?.expanded !== true}"
+                                (click)="toggleExpanded(launcherComponent.summary.pipeline)">
+                          </span>
+                  </div>
+                  <div class="list-view-pf-main-info"
+                      (click)="pipelineId = launcherComponent.summary?.pipeline?.id; updatePipelineSelection(pipeline)">
+                    <div class="list-view-pf-body">
+                      <div class="list-view-pf-description">
+                        <ng-container *ngFor="let stage of launcherComponent.summary?.pipeline?.stages; let i = index">
+                              <span class="f8launcher-pipeline-stages--line">
+                                <span class="f8launcher-pipeline-stages--name">
+                                  {{stage.name || stage}}
+                                </span>
+                              </span>
+                          <span class="f8launcher-pipeline-stages--arrow"
+                                *ngIf="i !== launcherComponent.summary?.pipeline?.stages.length - 1"></span>
+                        </ng-container>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent.summary?.pipeline?.suggested === true}"
+                        *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
                           *ngIf="launcherComponent.summary?.pipeline?.suggested === true">
-                      Suggested <i class="pficon pficon-info"></i>
+                      Red Hat Suggests <i class="pficon pficon-info"></i>
                     </span>
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
@@ -131,29 +154,6 @@
                           *ngIf="launcherComponent.summary?.pipeline?.techpreview === true">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
-                  </div>
-                </div>
-                <div class="list-view-pf-expand">
-                        <span class="fa"
-                              [ngClass]="{'fa-angle-down': launcherComponent.summary?.pipeline?.expanded === true,
-                                          'fa-angle-right': launcherComponent.summary?.pipeline?.expanded !== true}"
-                              (click)="toggleExpanded(launcherComponent.summary.pipeline)">
-                        </span>
-                </div>
-                <div class="list-view-pf-main-info"
-                     (click)="pipelineId = launcherComponent.summary?.pipeline?.id; updatePipelineSelection(pipeline)">
-                  <div class="list-view-pf-body">
-                    <div class="list-view-pf-description">
-                      <ng-container *ngFor="let stage of launcherComponent.summary?.pipeline?.stages; let i = index">
-                            <span class="f8launcher-pipeline-stages--line">
-                              <span class="f8launcher-pipeline-stages--name">
-                                {{stage.name || stage}}
-                              </span>
-                            </span>
-                        <span class="f8launcher-pipeline-stages--arrow"
-                              *ngIf="i !== launcherComponent.summary?.pipeline?.stages.length - 1"></span>
-                      </ng-container>
-                    </div>
                   </div>
                 </div>
                 <div class="list-group-item-container container-fluid"

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.less
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.less
@@ -9,8 +9,17 @@
       margin-left: 0;
     }
     .list-group-item {
-      &.suggested {
-        border-top: 1px solid @color-pf-blue;
+      padding-top: 0;
+      padding-bottom: 0;
+      .group {
+        flex: 1;
+        flex-direction: column;
+
+        &.with-tag {
+          padding-bottom: 20px;
+          position: relative;
+        }
+
       }
     }
     .list-group-item-header {

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
@@ -24,52 +24,55 @@
                 <div class="list-group-item"
                      [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techpreview === true}"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                  <div class="list-group-item-header">
-                    <div class="f8launcher-tags"
-                        *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
-                      <span class="f8launcher-tags-label suggested" container="body" triggers="click"
-                            outsideClick="true"
-                            popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                            *ngIf="pipeline.suggested === true">
-                        Suggested <i class="pficon pficon-info"></i>
-                      </span>
-                      <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
-                            outsideClick="true"
-                            popover="Technology Preview"
-                            *ngIf="pipeline.techpreview === true">
-                        Tech Preview <i class="pficon pficon-info"></i>
-                      </span>
-                    </div>
-                  </div>
-                  <div class="list-view-pf-expand">
-                        <span class="fa"
-                              [ngClass]="{'fa-angle-down': pipeline.expanded === true,
-                                          'fa-angle-right': pipeline.expanded !== true}"
-                              (click)="toggleExpanded(pipeline)">
-                        </span>
-                  </div>
-                  <div class="list-view-pf-checkbox">
-                    <input name="pipelineId" type="radio"
-                           [(ngModel)]="pipelineId"
-                           [value]="pipeline.id"
-                           (ngModelChange)="updatePipelineSelection(pipeline)">
-                  </div>
-                  <div class="list-view-pf-main-info"
-                       (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)">
-                    <div class="list-view-pf-body">
-                      <div class="list-view-pf-description">
-                        <ng-container *ngFor="let stage of pipeline.stages; let i = index">
-                            <span class="f8launcher-pipeline-stages--line">
-                              <span class="f8launcher-pipeline-stages--name">
-                                {{stage.name || stage}}
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techpreview === true}">
+                        <div class="list-view-pf-expand">
+                              <span class="fa"
+                                    [ngClass]="{'fa-angle-down': pipeline.expanded === true,
+                                                'fa-angle-right': pipeline.expanded !== true}"
+                                    (click)="toggleExpanded(pipeline)">
                               </span>
+                        </div>
+                        <div class="list-view-pf-checkbox">
+                          <input name="pipelineId" type="radio"
+                                [(ngModel)]="pipelineId"
+                                [value]="pipeline.id"
+                                (ngModelChange)="updatePipelineSelection(pipeline)">
+                        </div>
+                        <div class="list-view-pf-main-info"
+                            (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)">
+                          <div class="list-view-pf-body">
+                            <div class="list-view-pf-description">
+                              <ng-container *ngFor="let stage of pipeline.stages; let i = index">
+                                  <span class="f8launcher-pipeline-stages--line">
+                                    <span class="f8launcher-pipeline-stages--name">
+                                      {{stage.name || stage}}
+                                    </span>
+                                  </span>
+                                <span class="f8launcher-pipeline-stages--arrow"
+                                      *ngIf="i !== pipeline.stages.length - 1"></span>
+                              </ng-container>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested === true}"
+                              *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
+                            <span class="f8launcher-tags-label suggested" container="body" triggers="click"
+                                  outsideClick="true"
+                                  popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
+                                  *ngIf="pipeline.suggested === true">
+                              Red Hat Suggests <i class="pficon pficon-info tag-icon"></i>
                             </span>
-                          <span class="f8launcher-pipeline-stages--arrow"
-                                *ngIf="i !== pipeline.stages.length - 1"></span>
-                        </ng-container>
-                      </div>
-                    </div>
-                  </div>
+                            <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
+                                  outsideClick="true"
+                                  popover="Technology Preview"
+                                  *ngIf="pipeline.techpreview === true">
+                              Tech Preview <i class="pficon pficon-info"></i>
+                            </span>
+                          </div>
+                     </div>
+
+
+
                   <div class="list-group-item-container container-fluid"
                        (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)"
                        *ngIf="pipeline.expanded === true">

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.less
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.less
@@ -13,23 +13,20 @@
     }
   }
   .list-group-item {
-    &.suggested {
-      border-top: 1px solid @color-pf-blue;
-    }
 
-    .f8launcher-pipeline-stages--line {
-      position: relative;
-      padding-bottom: 5px;
-      &:after {
-        position: absolute;
-        right: unset;
-        left: 45%;
-        bottom: -12px;
+    .group {
+      flex: 1;
+      flex-direction: column;
+
+      &.with-tag {
+        padding-bottom: 20px;
+        position: relative;
       }
+
     }
 
-    .f8launcher-pipeline-stages--arrow {
-      margin-top: 30px;
+    .list-view-pf-main-info {
+      position: relative;
     }
   }
   .list-group-item-header {

--- a/src/assets/stylesheets/shared/_labels.less
+++ b/src/assets/stylesheets/shared/_labels.less
@@ -1,38 +1,70 @@
 @import (reference) 'main.less';
 
 .f8launcher-tags {
-  /* borders are ordered */
-  &.prerequisite {
-    border-top: 1px solid @color-pf-orange;
-  }
-  &.suggested, &.techpreview {
-    border-top: 1px solid @color-pf-blue;
-  }
-  &.contribute {
-    border-top: 1px solid @color-pf-green;
-  }
-  &:last-child {
-    margin-right: 0;
-  }
-  &-label {
-    margin-left: 5px;
-    padding: 0 10px;
-    color: @color-pf-white;
-    cursor: pointer;
-    font-size: .9em;
-    float: right;
-    i {
-      color: @color-pf-white;
+    position: absolute;
+    right: -15px;
+    height: 100%;
+    display: flex;
+    flex-direction: column-reverse;
+    border-color: inherit;
+    border-right: 3px solid;
+    border-bottom: 4px solid;
+    bottom: 0;
+    &:before {
+        content: '';
+        display: block;
+        width: 5px;
+        height: 3px;
+        position: absolute;
+        top: 0;
+        right: 0;
     }
-    /* labels are ordered */
-    &.prerequisite {
-      background-color: @color-pf-orange;
+    &.advanced-feature-tag {
+        @advanced-color: @color-pf-orange-400;
+        color: @advanced-color;
+        border-color: @advanced-color;
+        &:before {
+            background: @advanced-color;
+        }
+        .f8launcher-tags-label {
+            color: @advanced-color;
+            background: @color-pf-orange-100;
+        }
     }
-    &.suggested, &.techpreview {
-      background-color: @color-pf-blue;
+    &.not-available-feature-tag {
+        @not-avail-color: @color-pf-black-700;
+        border-color: @not-avail-color;
+        color: @not-avail-color;
+        &:before {
+            background: @not-avail-color;
+        }
+        .f8launcher-tags-label {
+            color: @not-avail-color;
+            background: @color-pf-black-200;
+        }
     }
-    &.contribute {
-      background-color: @color-pf-green;
+    &.suggested-feature-tag {
+        @suggested-color: @color-pf-blue;
+        border-color: @suggested-color;
+        color: @suggested-color;
+        &:before {
+            background: @suggested-color;
+        }
+        .f8launcher-tags-label {
+            color: @suggested-color;
+            background: @color-pf-blue-50;
+        }
     }
-  }
+
+    .f8launcher-tags-label {
+        right: 0;
+        padding: 0 5px;
+        cursor: pointer;
+        font-size: .9em;
+        bottom: 0;
+        margin-left: 0;
+        .tag-icon {
+          color: inherit;
+        }
+    }
 }

--- a/src/assets/stylesheets/shared/_pipelines.less
+++ b/src/assets/stylesheets/shared/_pipelines.less
@@ -6,13 +6,15 @@
   margin-bottom: 15px;
   margin-left: 57px;
   &--line {
+    position: relative;
     border-bottom: 5px solid @color-pf-blue;
     padding-left: 5px;
     padding-right: 5px;
+    padding-bottom: 10px;
     &:after {
-      position: relative;
-      right: 45%;
-      bottom: -19px;
+      position: absolute;
+      left: 40%;
+      bottom: -11px;
       width: 25px;
       height: 25px;
       content: '\f111';
@@ -29,7 +31,7 @@
     width: 25px;
     height: 2px;
     position: relative;
-    margin-top: 35px;
+    margin-top: 30px;
     margin-right: 20px;
     margin-left: 20px;
     background: @color-pf-blue;


### PR DESCRIPTION
fix(ux): changes the styles of tags

As per UX, the styles of tags have to be changed. This is how it will look once this PR will get merged.
<img width="924" alt="screen shot 2018-04-11 at 8 19 27 pm" src="https://user-images.githubusercontent.com/7880465/38624483-ca5b29c8-3dc5-11e8-9697-0ac39b017573.png">


fix(bug): handles the pipeline summary view bug
In Pipeline card of the summary tab, the pipelines look distorted. This happens if you select a pipeline with more number of stages.
<img width="1268" alt="screen shot 2018-04-11 at 6 30 37 pm" src="https://user-images.githubusercontent.com/7880465/38624549-f2f3f306-3dc5-11e8-9e20-dd8725d981fd.png">

And this PR handles that and after mer
<img width="918" alt="screen shot 2018-04-11 at 8 22 38 pm" src="https://user-images.githubusercontent.com/7880465/38624616-26b962b6-3dc6-11e8-8668-1cab02d2b6fc.png">
ging, the card will look like below
