### PR TITLE
fix(issues): pre-fill gitHub repo name, remove extra space, link to ope…

### DIFF
--- a/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.ts
+++ b/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.ts
@@ -128,7 +128,8 @@ export class GitproviderCreateappStepComponent extends LauncherStep implements A
     if (this.launcherComponent && this.launcherComponent.summary &&
       this.launcherComponent.summary.gitHubDetails) {
       org = this.launcherComponent.summary.gitHubDetails.organization;
-      this.launcherComponent.summary.gitHubDetails.repository = '';
+      this.launcherComponent.summary.gitHubDetails.repository =
+      this.launcherComponent.summary.dependencyCheck ? this.launcherComponent.summary.dependencyCheck.projectName : '';
       this.launcherComponent.summary.gitHubDetails.repositoryList = [];
     }
 
@@ -140,6 +141,7 @@ export class GitproviderCreateappStepComponent extends LauncherStep implements A
       if (val !== undefined && this.launcherComponent && this.launcherComponent.summary &&
         this.launcherComponent.summary.gitHubDetails) {
         this.launcherComponent.summary.gitHubDetails.repositoryList = val;
+        this.validateRepo();
       }
     });
   }

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
@@ -25,7 +25,7 @@
     <div class="container-fluid container-cards-pf">
       <div class="row row-cards-pf">
         <div class="col-xs-12 col-md-6">
-          <div class="card-pf card-pf--large">
+          <div class="card-pf card-pf--small">
             <div class="card-pf-heading">
               <h2 class="card-pf-title">
                 Choose a mission
@@ -111,7 +111,7 @@
           </div>
         </div>
         <div class="col-xs-12 col-md-6">
-          <div class="card-pf card-pf--large">
+          <div class="card-pf card-pf--small">
             <div class="card-pf-heading">
               <h2 class="card-pf-title">
                 Choose a runtime

--- a/src/app/launcher/create-app/project-progress-createapp-nextstep/project-progress-createapp-nextstep.component.html
+++ b/src/app/launcher/create-app/project-progress-createapp-nextstep/project-progress-createapp-nextstep.component.html
@@ -63,7 +63,7 @@
                         </div>
                         <div class="list-pf-actions"
                           *ngIf="item.hyperText !== undefined && item.completed === true">
-                          <a [href]="item.hyperText">{{item.hyperText}}</a>
+                          <a target="_blank" [href]="item.hyperText">{{item.hyperText}}</a>
                         </div>
                       </div>
                     </div>

--- a/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.html
+++ b/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.html
@@ -63,7 +63,7 @@
                         </div>
                         <div class="list-pf-actions"
                           *ngIf="item?.hyperText !== undefined && item?.completed === true">
-                          <a [href]="item?.hyperText">{{item?.hyperText}}</a>
+                          <a target="_blank" [href]="item?.hyperText">{{item?.hyperText}}</a>
                         </div>
                       </div>
                     </div>

--- a/src/assets/stylesheets/shared/_cards.less
+++ b/src/assets/stylesheets/shared/_cards.less
@@ -19,7 +19,7 @@
         min-height: 550px;
       }
       &--large {
-        min-height: 500px;
+        min-height: 860px;
       }
       &-title {
         display: inline-flex;


### PR DESCRIPTION
- pre-fill GitHub repo name
- remove extra space on runtime/mission screen
- link to open in a new window

Tracks : 
- https://github.com/openshiftio/openshift.io/issues/3223
- https://github.com/openshiftio/openshift.io/issues/3138