### PR TITLE
fix(image): put back the image for runtime screen

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
@@ -168,6 +168,12 @@
                   </div>
                   <div class="list-view-pf-main-info"
                        (click)="updateRuntimeSelection(runtime)">
+                    <div class="list-view-pf-left">
+                      <span class="list-view-pf-logo">
+                        <img [src]="_DomSanitizer.bypassSecurityTrustUrl(runtime.icon)"
+                             *ngIf="runtime.icon !== null">
+                      </span>
+                    </div>
                     <div class="list-view-pf-body f8launcher-section-runtime"
                          (click)="updateRuntimeSelection(runtime)">
                       <div class="list-view-pf-description">


### PR DESCRIPTION
Runtime has icons/images associated next to it to visually indicate the runtimes.

This PR adds them.