### PR TITLE
fix(summary): validation for summary screen

### DIFF
--- a/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.html
+++ b/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.html
@@ -34,7 +34,7 @@
               <div class="col-sm-10 f8launcher-provider-card-information-authorize">
                   <img height="30px" width="30px" [src]="launcherComponent?.summary?.gitHubDetails?.avatar"
                        *ngIf="launcherComponent?.summary?.gitHubDetails?.avatar !== undefined">
-                  <span *ngIf="launcherComponent?.summary?.gitHubDetails?.login !== undefined">
+                  <span class="f8launcher-username-login" *ngIf="launcherComponent?.summary?.gitHubDetails?.login !== undefined">
                     {{launcherComponent?.summary?.gitHubDetails?.login}}
                   </span>
                   <i class="fa fa-ban fa-2x" *ngIf="launcherComponent?.summary?.gitHubDetails?.avatar === undefined"></i>

--- a/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/gitprovider-createapp-step/gitprovider-createapp-step.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -14,10 +14,24 @@ import { PipeModule } from 'patternfly-ng/pipe';
 import { LauncherComponent } from '../../launcher.component';
 import { LauncherStep } from '../../launcher-step';
 
+import { DependencyCheck } from '../../launcher.module';
+import { DependencyCheckService } from '../../service/dependency-check.service';
 import { GitproviderCreateappStepComponent } from './gitprovider-createapp-step.component';
 import { GitProviderService } from '../../service/git-provider.service';
 
 import { GitHubDetails } from '../../model/github-details.model';
+
+let mockDependencyCheckService = {
+  getDependencyCheck(): Observable<DependencyCheck> {
+    return Observable.of({
+      mavenArtifact: 'd4-345',
+      groupId: 'io.openshift.booster',
+      projectName: 'App_test_1',
+      projectVersion: '1.0.0-SNAPSHOT',
+      spacePath: '/myspace'
+    });
+  }
+};
 
 let mockGitProviderService = {
   connectGitHubAccount(redirectUrl: string): void {
@@ -84,6 +98,7 @@ let mockWizardComponent: TypeWizardComponent = {
 describe('GitProviderStepComponent', () => {
   let component: GitproviderCreateappStepComponent;
   let fixture: ComponentFixture<GitproviderCreateappStepComponent>;
+  let element: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -99,6 +114,9 @@ describe('GitProviderStepComponent', () => {
         GitproviderCreateappStepComponent
       ],
       providers: [
+        {
+          provide: DependencyCheckService, useValue: mockDependencyCheckService
+        },
         {
           provide: GitProviderService, useValue: mockGitProviderService
         },
@@ -121,4 +139,28 @@ describe('GitProviderStepComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render users git avatar', () => {
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    let userGitAvatar = element.querySelector('.f8launcher-provider-card-information-authorize>img');
+    expect(userGitAvatar.getAttribute('src')).toContain('https://avatars3.githubusercontent.com/u/17882357?v=4');
+  });
+
+  it('should show users login', () => {
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    let userGitLogin = element.
+      querySelector('.f8launcher-provider-card-information-authorize .f8launcher-username-login');
+    expect(userGitLogin.innerHTML).toContain('testuser');
+  });
+
+  it('should disable logIn button', () => {
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    let userGitLoginBtn = element.
+      querySelector('.f8launcher-provider-card-information-authorize .f8launcher-authorize-account');
+    expect(userGitLoginBtn.hasAttribute('disabled'));
+  });
+
 });

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.ts
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.ts
@@ -78,6 +78,13 @@ export class ProjectSummaryCreateappStepComponent extends LauncherStep implement
    */
   get stepCompleted(): boolean {
     let completed = true;
+    if ((this.launcherComponent.isProjectNameValid !== undefined && this.launcherComponent.isProjectNameValid === false)
+    || (this.launcherComponent.isGroupIdValid !== undefined && this.launcherComponent.isGroupIdValid === false)
+    || (this.launcherComponent.isArtifactIdValid !== undefined && this.launcherComponent.isArtifactIdValid === false)
+    || (this.launcherComponent.isProjectVersionValid !== undefined &&
+      this.launcherComponent.isProjectVersionValid === false)) {
+      return false;
+    }
     for (let i = 0; i < this.launcherComponent.steps.length - 1; i++) {
       let step = this.launcherComponent.steps[i];
       if (!(step.optional === true || step.completed === true) && step.hidden !== true) {
@@ -139,11 +146,18 @@ export class ProjectSummaryCreateappStepComponent extends LauncherStep implement
     }
     if (!pattern.test(repoName)) {
       this.launcherComponent.summary.gitHubDetails.repositoryAvailable = false;
+      let gitStep = this.launcherComponent.getStep('GitProvider');
+      gitStep.completed = false;
     } else if (repoList.indexOf(repoName) !== -1) {
       this.launcherComponent.summary.gitHubDetails.repositoryAvailable = false;
+      let gitStep = this.launcherComponent.getStep('GitProvider');
+      gitStep.completed = false;
     } else {
       this.launcherComponent.summary.gitHubDetails.repositoryAvailable = true;
+      let gitStep = this.launcherComponent.getStep('GitProvider');
+      gitStep.completed = true;
     }
+    this.initCompleted();
   }
 
   /**

--- a/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.html
+++ b/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.html
@@ -33,7 +33,7 @@
               <div class="col-sm-10 f8launcher-provider-card-information-authorize">
                   <img height="30px" width="30px" [src]="launcherComponent?.summary?.gitHubDetails?.avatar"
                        *ngIf="launcherComponent?.summary?.gitHubDetails?.avatar !== undefined">
-                  <span *ngIf="launcherComponent?.summary?.gitHubDetails?.login !== undefined">
+                  <span class="f8launcher-username-login" *ngIf="launcherComponent?.summary?.gitHubDetails?.login !== undefined">
                     {{launcherComponent?.summary?.gitHubDetails?.login}}
                   </span>
                   <i class="fa fa-ban fa-2x" *ngIf="launcherComponent?.summary?.gitHubDetails?.avatar === undefined"></i>

--- a/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.spec.ts
+++ b/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -13,10 +13,24 @@ import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { LauncherComponent } from '../../launcher.component';
 import { LauncherStep } from '../../launcher-step';
 
+import { DependencyCheck } from '../../launcher.module';
+import { DependencyCheckService } from '../../service/dependency-check.service';
 import { GitproviderImportappStepComponent } from './gitprovider-importapp-step.component';
 import { GitProviderService } from '../../service/git-provider.service';
 
 import { GitHubDetails } from '../../model/github-details.model';
+
+let mockDependencyCheckService = {
+  getDependencyCheck(): Observable<DependencyCheck> {
+    return Observable.of({
+      mavenArtifact: 'd4-345',
+      groupId: 'io.openshift.booster',
+      projectName: 'App_test_1',
+      projectVersion: '1.0.0-SNAPSHOT',
+      spacePath: '/myspace'
+    });
+  }
+};
 
 let mockGitProviderService = {
   connectGitHubAccount(redirectUrl: string): void {
@@ -83,6 +97,7 @@ let mockWizardComponent: TypeWizardComponent = {
 describe('Import GitProviderStepComponent', () => {
   let component: GitproviderImportappStepComponent;
   let fixture: ComponentFixture<GitproviderImportappStepComponent>;
+  let element: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -97,6 +112,9 @@ describe('Import GitProviderStepComponent', () => {
         GitproviderImportappStepComponent
       ],
       providers: [
+        {
+          provide: DependencyCheckService, useValue: mockDependencyCheckService
+        },
         {
           provide: GitProviderService, useValue: mockGitProviderService
         },
@@ -119,4 +137,28 @@ describe('Import GitProviderStepComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render users git avatar', () => {
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    let userGitAvatar = element.querySelector('.f8launcher-provider-card-information-authorize>img');
+    expect(userGitAvatar.getAttribute('src')).toContain('https://avatars3.githubusercontent.com/u/17882357?v=4');
+  });
+
+  it('should show users login', () => {
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    let userGitLogin = element.
+      querySelector('.f8launcher-provider-card-information-authorize .f8launcher-username-login');
+    expect(userGitLogin.innerHTML).toContain('testuser');
+  });
+
+  it('should disable logIn button', () => {
+    fixture.detectChanges();
+    element = fixture.nativeElement;
+    let userGitLoginBtn = element.
+      querySelector('.f8launcher-provider-card-information-authorize .f8launcher-authorize-account');
+    expect(userGitLoginBtn.hasAttribute('disabled'));
+  });
+
 });

--- a/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.ts
+++ b/src/app/launcher/import-app/gitprovider-importapp-step/gitprovider-importapp-step.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
+import { DependencyCheckService } from '../../service/dependency-check.service';
 import { GitProviderService } from '../../service/git-provider.service';
 import { Selection } from '../../model/selection.model';
 import { LauncherComponent } from '../../launcher.component';
@@ -28,6 +29,7 @@ export class GitproviderImportappStepComponent extends LauncherStep implements A
   private gitHubReposSubscription: Subscription;
 
   constructor(@Host() public launcherComponent: LauncherComponent,
+              private dependencyCheckService: DependencyCheckService,
               private gitProviderService: GitProviderService) {
     super();
   }
@@ -159,6 +161,14 @@ export class GitproviderImportappStepComponent extends LauncherStep implements A
   }
 
   /**
+   * Validate the application name
+   */
+  validateProjectName(): void {
+    this.launcherComponent.isProjectNameValid =
+      this.dependencyCheckService.validateProjectName(this.launcherComponent.summary.dependencyCheck.projectName);
+  }
+
+  /**
    * Ensure repo name is available for the selected organization
    */
   validateRepo(): void {
@@ -169,6 +179,7 @@ export class GitproviderImportappStepComponent extends LauncherStep implements A
       if (this.launcherComponent.flow === 'osio') {
         this.launcherComponent.summary.dependencyCheck.projectName =
           this.launcherComponent.summary.gitHubDetails.repository;
+        this.validateProjectName();
       }
     }else {
       this.launcherComponent.summary.gitHubDetails.repositoryAvailable = false;

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.ts
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.ts
@@ -83,6 +83,13 @@ export class ProjectSummaryImportappStepComponent extends LauncherStep implement
    */
   get stepCompleted(): boolean {
     let completed = true;
+    if ((this.launcherComponent.isProjectNameValid !== undefined && this.launcherComponent.isProjectNameValid === false)
+    || (this.launcherComponent.isGroupIdValid !== undefined && this.launcherComponent.isGroupIdValid === false)
+    || (this.launcherComponent.isArtifactIdValid !== undefined && this.launcherComponent.isArtifactIdValid === false)
+    || (this.launcherComponent.isProjectVersionValid !== undefined &&
+      this.launcherComponent.isProjectVersionValid === false)) {
+      return false;
+    }
     for (let i = 0; i < this.launcherComponent.steps.length - 1; i++) {
       let step = this.launcherComponent.steps[i];
       if (!(step.optional === true || step.completed === true) && step.hidden !== true) {
@@ -137,13 +144,18 @@ export class ProjectSummaryImportappStepComponent extends LauncherStep implement
     let repoList = this.launcherComponent.summary.gitHubDetails.repositoryList;
     if (repoList.indexOf(repoName) !== -1) {
       this.launcherComponent.summary.gitHubDetails.repositoryAvailable = true;
+      let gitStep = this.launcherComponent.getStep('GitProvider');
+      gitStep.completed = true;
       if (this.launcherComponent.flow === 'osio') {
         this.launcherComponent.summary.dependencyCheck.projectName =
           this.launcherComponent.summary.gitHubDetails.repository;
       }
     }else {
       this.launcherComponent.summary.gitHubDetails.repositoryAvailable = false;
+      let gitStep = this.launcherComponent.getStep('GitProvider');
+      gitStep.completed = false;
     }
+    this.initCompleted();
   }
 
   /**

--- a/src/app/launcher/step-indicator/step-indicator.component.ts
+++ b/src/app/launcher/step-indicator/step-indicator.component.ts
@@ -96,17 +96,35 @@ export class StepIndicatorComponent implements OnInit {
   }
 
   /**
+   * Ensure repo name is available for the selected organization
+   */
+  validateImportRepo(): void {
+    let repoName = this.launcherComponent.summary.gitHubDetails.repository;
+    let repoList = this.launcherComponent.summary.gitHubDetails.repositoryList;
+    if (repoList.indexOf(repoName) !== -1) {
+      this.launcherComponent.summary.gitHubDetails.repositoryAvailable = true;
+    }else {
+      this.launcherComponent.summary.gitHubDetails.repositoryAvailable = false;
+    }
+  }
+
+  /**
    * Validate the application name
    */
   validateProjectName(): void {
     this.launcherComponent.isProjectNameValid =
       this.dependencyCheckService.validateProjectName(this.launcherComponent.summary.dependencyCheck.projectName);
-    if (this.launcherComponent.flow === 'osio') {
-      this.launcherComponent.summary.dependencyCheck.projectName = this.launcherComponent.summary.dependencyCheck.projectName.toLowerCase();
-      this.launcherComponent.summary.gitHubDetails.repository =
-        this.launcherComponent.summary.dependencyCheck.projectName;
-      this.validateRepo();
-    }
+      if (this.launcherComponent.flow === 'osio') {
+        this.launcherComponent.summary.dependencyCheck.projectName =
+          this.launcherComponent.summary.dependencyCheck.projectName.toLowerCase();
+        this.launcherComponent.summary.gitHubDetails.repository =
+          this.launcherComponent.summary.dependencyCheck.projectName;
+      }
+      if (this.launcherComponent.importApp) {
+        this.validateImportRepo();
+      } else {
+        this.validateRepo();
+      }
   }
 
   // Private


### PR DESCRIPTION
- Handled validation for setup App Button in summary screen i.e Setup should be disabled if ProjectName, GroupID, Version, ArtifactID is not valid
- Issue with two way binding issue for repoName and app name
- Adds tests for git provider component

Tracks : 
https://github.com/openshiftio/openshift.io/issues/3548