### PR TITLE
fix: mission not available so no check for runs on cluster.

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
@@ -259,6 +259,9 @@ export class MissionRuntimeCreateappStepComponent extends LauncherStep implement
       return false;
     }
     let selectedMission = runtime.missions.find(m => m.id === this.launcherComponent.summary.mission.id);
+    if (!selectedMission) {
+      return true;
+    }
     let version = selectedMission.versions.find(v => v.booster !== undefined);
     return version? !this.checkRunsOnCluster(version.booster.metadata.runsOn, this.launcherComponent.summary.cluster.type) : false;
   }


### PR DESCRIPTION
Selected mission not available for the specific runtime we'll show another not availble sign. So we return true in this case.

fixes: https://github.com/fabric8-launcher/launcher-frontend/issues/359