### PR TITLE
fix: improve cluster authorization

### DIFF
--- a/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.html
+++ b/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.html
@@ -10,9 +10,9 @@
       </div>
     </div>
   </div>
-  <div class="list-group-item" *ngFor="let cluster of clusters" (click)="isChecked(cluster) ? selectCluster(cluster) : null" [class.disabled]="!isChecked(cluster)">
+  <div class="list-group-item" *ngFor="let cluster of clusters" (click)="cluster.connected ? selectCluster(cluster) : null" [class.disabled]="!cluster.connected">
     <div class="list-view-pf-checkbox">
-      <input name="cluster" type="radio" [(ngModel)]="clusterId" [value]="cluster.id" [disabled]="!isChecked(cluster)">
+      <input name="cluster" type="radio" [(ngModel)]="clusterId" [value]="cluster.id" [disabled]="!cluster.connected">
     </div>
     <div class="list-view-pf-main-info">
       <div class="list-view-pf-left">
@@ -21,8 +21,10 @@
       <div class="list-view-pf-body">
         <div class="list-view-pf-description">
           Openshift ({{cluster.id}}) &nbsp;
-          <a [href]="tokenService.createOathLink(cluster.id)" class="btn btn-default" *ngIf="!isChecked(cluster)">Add</a>
         </div>
+      </div>
+      <div class="list-view-pf-actions" *ngIf="!cluster.connected">
+        <a [href]="tokenService.createOathLink(cluster.id)" class="btn btn-default">Authorize</a>
       </div>
     </div>
   </div>

--- a/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.less
+++ b/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.less
@@ -22,4 +22,9 @@ span.fa.pficon-server.list-view-pf-icon-sm.openshift {
     padding-bottom: 10px;
     padding-top: 10px;
   }
+  .list-view-pf-actions {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+
 }

--- a/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.ts
+++ b/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.ts
@@ -9,25 +9,37 @@ import { Observable } from 'rxjs';
   templateUrl: './link-accounts-createapp-step.component.html',
   styleUrls: ['./link-accounts-createapp-step.component.less']
 })
+
+
+
 export class LinkAccountsCreateappStepComponent {
   @Output() select = new EventEmitter();
+  private _clusters: Cluster[] = [];
   private clusterId: string;
-  availableClusters: Cluster[] = [];
-  clusters: Cluster[] = [];
 
   constructor(@Optional() private tokenService: TokenService) {
-    if (tokenService) {
-      tokenService.clusters.subscribe(clusters => this.clusters = clusters);
-      tokenService.availableClusters.subscribe(clusters => this.availableClusters = clusters);
-    }
-  }
-
-  isChecked(token: Cluster): boolean {
-    return this.availableClusters.map(cluster => cluster.id).indexOf(token.id) !== -1;
+    this.load();
   }
 
   selectCluster(cluster: Cluster): void {
     this.clusterId = cluster.id;
     this.select.emit(cluster);
+  }
+
+  get clusters(): Cluster[] {
+    return this._clusters;
+  }
+
+  private load() {
+    if (this.tokenService) {
+      this.tokenService.clusters.subscribe(clusters => this._clusters = clusters.sort(this.clusterSortFn));
+    }
+  }
+
+  private clusterSortFn(a: Cluster, b: Cluster): number {
+    if (a.connected) {
+      return -1;
+    }
+    return a.id.localeCompare(b.id);
   }
 }

--- a/src/app/launcher/model/cluster.model.ts
+++ b/src/app/launcher/model/cluster.model.ts
@@ -1,4 +1,5 @@
 export class Cluster {
   id: string;
   type: string;
+  connected: boolean;
 }

--- a/src/app/launcher/service/token.service.ts
+++ b/src/app/launcher/service/token.service.ts
@@ -2,8 +2,6 @@ import { Cluster } from '../model/cluster.model';
 import { Observable } from 'rxjs';
 
 export abstract class TokenService {
-
-  abstract get availableClusters(): Observable<Cluster[]>;
   abstract get clusters(): Observable<Cluster[]>;
   abstract createOathLink(cluster: string): string;
 }

--- a/src/demo/service/demo-target-environment.service.ts
+++ b/src/demo/service/demo-target-environment.service.ts
@@ -20,7 +20,7 @@ export class DemoTargetEnvironmentService implements TargetEnvironmentService {
    * @returns {Observable<TargetEnvironment>} The target environments
    */
   getTargetEnvironments(): Observable<TargetEnvironment[]> {
-    return this.tokenService.availableClusters.map(clusters => [{
+    return this.tokenService.clusters.map(clusters => [{
       benefits: [
         'A repository is created in GitHub containing your new application’s code.',
         'Edit the code locally using the tool of your choice.',

--- a/src/demo/service/demo-target-environment.service.ts
+++ b/src/demo/service/demo-target-environment.service.ts
@@ -32,7 +32,7 @@ export class DemoTargetEnvironmentService implements TargetEnvironmentService {
       /* tslint:enable */
       id: 'os',
       styleClass: 'card-pf-footer--logo-os',
-      clusters: clusters
+      clusters: clusters.filter(c => c.connected)
     }, {
       benefits: [
         'Scaffolding for your new application is generated.',

--- a/src/demo/service/demo-token.service.ts
+++ b/src/demo/service/demo-token.service.ts
@@ -1,66 +1,58 @@
-import { Injectable } from '@angular/core';
-import { Headers, Http, RequestOptions, Response } from '@angular/http';
-import { Observable } from "rxjs";
+import {Injectable} from '@angular/core';
+import {Observable} from 'rxjs';
 
-import { TokenService } from "../../app/launcher/service/token.service";
-import { HelperService } from '../../app/launcher/service/helper.service';
-import { TokenProvider } from '../../app/service/token-provider';
-import { Cluster } from '../../app/launcher/model/cluster.model';
+import {TokenService} from '../../app/launcher/service/token.service';
+import {Cluster} from '../../app/launcher/model/cluster.model';
 
 @Injectable()
 export class DemoTokenService implements TokenService {
 
-  get availableClusters(): Observable<Cluster[]> {
-    return Observable.of([
-      {
-        "id": "starter-ca-central-1",
-        "type": "starter"
-      },
-      {
-        "id": "starter-us-west-1",
-        "type": "starter"
-      }
-    ]);
-  };
-
   get clusters(): Observable<Cluster[]> {
     return Observable.of([
       {
-        "id": "starter-us-east-1",
-        "type": "starter"
+        'id': 'starter-us-east-1',
+        'type': 'starter',
+        'connected': true
       },
       {
-        "id": "starter-us-west-1",
-        "type": "starter"
+        'id': 'starter-us-west-1',
+        'type': 'starter',
+        'connected': false
       },
       {
-        "id": "starter-us-west-2",
-        "type": "starter"
+        'id': 'starter-us-west-2',
+        'type': 'starter',
+        'connected': false
       },
       {
-        "id": "starter-ca-central-1",
-        "type": "starter"
+        'id': 'starter-ca-central-1',
+        'type': 'starter',
+        'connected': true
       },
       {
-        "id": "pro-us-east-1",
-        "type": "pro"
+        'id': 'pro-us-east-1',
+        'type': 'pro',
+        'connected': false
       },
       {
-        "id": "pro-eu-west-1",
-        "type": "pro"
+        'id': 'pro-eu-west-1',
+        'type': 'pro',
+        'connected': false
       },
       {
-        "id": "pro-ap-southeast-2",
-        "type": "pro"
+        'id': 'pro-ap-southeast-2',
+        'type': 'pro',
+        'connected': false
       },
       {
-        "id": "online-stg",
-        "type": "internal"
+        'id': 'online-stg',
+        'type': 'internal',
+        'connected': false
       }
     ]);
   }
 
   createOathLink(cluster: string): string {
-    return "oath-link?" + cluster;
+    return `oath-link?${cluster}`;
   }
 }


### PR DESCRIPTION
- Align buttons to the right of the screen
- Sort already authorized first
- Change label to "Authorize" instead of "Add"
- Make only one call to get the cluster list

BREAKING CHANGES:
- Added `connected: boolean` to `Cluster` model
- Remove `availableClusters` method from TokenService interface

Closes #217