### PR TITLE
fix(build): fixes error that happens during npm start of standalone launcher.

### DIFF
--- a/config/webpack.demo.js
+++ b/config/webpack.demo.js
@@ -93,12 +93,26 @@ module.exports = {
           }
         ],
       }, {
-        test: /\.css$/,
-        loader: extractCSS.extract({
+        test: /^(?!.*component).*\.css$/,
+        use: extractCSS.extract({
           fallback: "style-loader",
           use: "css-loader?sourceMap&context=/"
         }),
         exclude: [/node_modules\/@swimlane\/ngx-datatable/]
+      }, {
+        test: /\.component\.css$/,
+        use: [
+          {
+            loader: 'to-string-loader'
+          }, {
+            loader: 'css-loader',
+            options: {
+              minimize: true,
+              sourceMap: true,
+              context: '/'
+            }
+          }
+        ],
       }, {
         test: /\.less$/,
         loaders: [

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@angular/http": "4.4.6",
     "@thisissoon/angular-inviewport": "1.3.2",
     "angular-2-dropdown-multiselect": "1.6.0",
-    "fabric8-analytics-dependency-editor": "0.0.8-development",
+    "fabric8-analytics-dependency-editor": "0.0.10",
     "ngx-bootstrap": "1.9.3",
     "ngx-modal": "0.0.29",
     "patternfly": "3.30.1",


### PR DESCRIPTION
fix(build): fixes error that happens during npm start of standalone launcher.
fix(version): updates fabric8-analytics-dependency-editor to 0.0.10