### PR TITLE
fix: version can be undefined

### DIFF
--- a/src/app/launcher/create-app/dependency-editor-step/dependency-editor-step.component.ts
+++ b/src/app/launcher/create-app/dependency-editor-step/dependency-editor-step.component.ts
@@ -155,7 +155,7 @@ export class DependencyEditorCreateappStepComponent extends LauncherStep impleme
                 this.cacheInfo['runtime'] = {
                     name: current.name,
                     id: current.id,
-                    version: current.version.id
+                    version: current.version ? current.version.id : null
                 };
                 flag = true;
             }


### PR DESCRIPTION
When you select a runtime first and then a mission version will be undefined

fixes https://github.com/fabric8-launcher/launcher-frontend/issues/366