### PR TITLE
fix: target env selection invalid completion and optimized clusters fetching

### DIFF
--- a/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.ts
+++ b/src/app/launcher/create-app/link-accounts-createapp-step/link-accounts-createapp-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, Optional, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
+import { Component, Optional, Output, EventEmitter, ChangeDetectorRef, Input } from '@angular/core';
 
 import { Cluster } from '../../model/cluster.model';
 import { TokenService } from '../../service/token.service';
@@ -11,16 +11,11 @@ import { Observable } from 'rxjs';
 })
 export class LinkAccountsCreateappStepComponent {
   @Output() select = new EventEmitter(true);
-  private _clusters: Cluster[] = [];
+  @Input() clusters: Cluster[] = [];
   private clusterId: string;
 
 
   constructor(@Optional() private tokenService: TokenService, private changeDetector: ChangeDetectorRef) {
-    if (this.tokenService) {
-      tokenService.clusters.subscribe(clusters => {
-        this._clusters = clusters.sort(this.clusterSortFn);
-      });
-    }
   }
 
   ngAfterViewInit() {
@@ -32,22 +27,11 @@ export class LinkAccountsCreateappStepComponent {
     this.select.emit(cluster);
   }
 
-  get clusters(): Cluster[] {
-    return this._clusters;
-  }
-
   private autoSetCluster(): void {
-    const connectedClusters = this._clusters.filter(c => c.connected);
+    const connectedClusters = this.clusters.filter(c => c.connected);
     if (connectedClusters.length === 1) {
       this.selectCluster(connectedClusters[0]);
       this.changeDetector.detectChanges();
     }
-  }
-
-  private clusterSortFn(a: Cluster, b: Cluster): number {
-    if (a.connected) {
-      return -1;
-    }
-    return a.id.localeCompare(b.id);
   }
 }

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
@@ -53,7 +53,7 @@ export class MissionRuntimeCreateappStepComponent extends LauncherStep implement
         this.initBoosters();
         this.restoreFromSummary();
       }));
-    this.broadcaster.on('cluster').subscribe(() => this.initBoosters());
+    this.subscriptions.push(this.broadcaster.on('cluster').subscribe(() => this.initBoosters()));
   }
 
   ngOnDestroy() {

--- a/src/app/launcher/create-app/targetenvironment-createapp-step/target-environment-createapp-step.component.html
+++ b/src/app/launcher/create-app/targetenvironment-createapp-step/target-environment-createapp-step.component.html
@@ -45,9 +45,13 @@
         </div>
       </div>
     </div>
-    <f8launcher-link-accounts-createapp-step
-      (select)="selectCluster($event)" *ngIf="launcherComponent?.summary?.targetEnvironment === 'os'">
-    </f8launcher-link-accounts-createapp-step>
+    <div *ngIf="launcherComponent?.summary?.targetEnvironment === 'os'">
+      <f8launcher-link-accounts-createapp-step
+        [clusters]="clusters"
+        (select)="selectCluster($event)"
+      >
+      </f8launcher-link-accounts-createapp-step>
+    </div>
   </div>
   <div>
     <div class="container-fluid">


### PR DESCRIPTION
- step is completed only if "os and cluster" are selected or "zip".
- clusters are now fetched in `TargetEnvironmentCreateappStepComponent` and passed as input to `LinkAccountsCreateappStepComponent`.
- unsubscribe to broacaster event in `MissionRuntimeCreateappStepComponent`.