### PR TITLE
fix: TypeError: Cannot read property 'id' of undefined in MissionRuntimeCreateappStepComponent

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
@@ -132,11 +132,11 @@ export class MissionRuntimeCreateappStepComponent extends LauncherStep implement
   }
 
   selectBooster(mission?: ViewMission, runtime?: ViewRuntime, version?: BoosterVersion): void {
-    if (mission) {
+    if (mission && !mission.disabled) {
       this.missionId = mission.id;
       this.launcherComponent.summary.mission = mission;
     }
-    if (runtime) {
+    if (runtime && !runtime.disabled) {
       this.runtimeId = runtime.id;
       const newVersion =  version ? version : runtime.selectedVersion;
       this.versionId = newVersion.id;

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.model.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.model.ts
@@ -8,7 +8,7 @@ import { EmptyReason } from '../../service/mission-runtime.service';
 export class ViewMission extends Mission {
   advanced: boolean;
   suggested: boolean;
-  disabled: boolean = false;
+  disabled: boolean;
   disabledReason?: EmptyReason;
   prerequisite: boolean;
   community: boolean;
@@ -17,7 +17,7 @@ export class ViewMission extends Mission {
 }
 
 export class ViewRuntime extends Runtime {
-  disabled: boolean = false;
+  disabled: boolean;
   disabledReason?: EmptyReason;
   prerequisite: boolean;
   canChangeVersion: boolean;
@@ -41,6 +41,7 @@ export function createViewRuntimes(boosters: Booster[], canChangeVersion: boolea
       suggested: _.get(runtime, 'metadata.suggested', false),
       prerequisite: _.get(runtime, 'metadata.prerequisite', false),
       showMore: false,
+      disabled: true,
       boosters: runtimeBoosters
     } as ViewRuntime;
   });
@@ -59,6 +60,7 @@ export function createViewMissions(boosters: Booster[]): ViewMission[] {
       suggested: _.get(mission, 'metadata.suggested', false),
       prerequisite: _.get(mission, 'metadata.prerequisite', false),
       showMore: false,
+      disabled: true,
       boosters: missionBoosters
     } as ViewMission;
   });


### PR DESCRIPTION
Make sure that disabled/not-loaded missions and runtimes are not selectable.

Closes https://github.com/fabric8-launcher/launcher-frontend/issues/478