### PR TITLE
patternfly-ng: restore exports for deprecated PipeModule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11271,9 +11271,9 @@
       }
     },
     "patternfly-ng": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/patternfly-ng/-/patternfly-ng-3.10.1.tgz",
-      "integrity": "sha512-3qBWN0CpBdEtmE5u/+uiC4LGQBVXXJnV4j86x/LCeu1BL2sMMPcaN9XrkJUIRKggv0H5CxZ3TWHrIhzmKBNPyA==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/patternfly-ng/-/patternfly-ng-3.10.3.tgz",
+      "integrity": "sha512-Qxz4rnoUsgttcFFsgts+7wtgfdAl+CzW6brai6z73gSMCa3alCO9oPbMdMgcZQzWigmlHVS+Vk9A1RTvBBGYjA==",
       "requires": {
         "@swimlane/ngx-datatable": "11.3.2",
         "angular-tree-component": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ngx-bootstrap": "^2.0.5",
     "ngx-modal": "^0.0.29",
     "patternfly": "^3.30.1",
-    "patternfly-ng": "^3.10.1"
+    "patternfly-ng": "^3.10.3"
   },
   "peerDependencies": {
     "@angular/animations": "^4.4.6",


### PR DESCRIPTION
For some reason, prod-preview appears to be pulling an older version of patternfly-ng. This will ensure the sortArray pipe still works properly with the deprecated PipeModule.