### PR TITLE
fix: clean version selection code for launch flow

### DIFF
--- a/src/app/launcher/model/booster.model.ts
+++ b/src/app/launcher/model/booster.model.ts
@@ -1,6 +1,7 @@
 export class BoosterVersion {
   id: string;
   name: string;
+  metadata?: any;
 }
 
 export class BoosterRuntime {

--- a/src/app/launcher/model/catalog.model.ts
+++ b/src/app/launcher/model/catalog.model.ts
@@ -6,16 +6,19 @@ export class CatalogMission {
   metadata?: any;
 }
 
+export class CatalogRuntimeVersion {
+  id: string;
+  name: string;
+  metadata?: any;
+}
+
 export class CatalogRuntime {
   id: string;
   name: string;
   description?: string;
   icon: string;
   metadata?: any;
-  versions: [{
-    id: string;
-    name: string;
-  }];
+  versions: CatalogRuntimeVersion[];
 }
 
 export class CatalogBooster {


### PR DESCRIPTION
Add `metadata.suggested` in versions.

Use the `MissionRuntimeService.compareVersions` sort algo to render versions in a specific order:
- first suggested
- then community (it's a workaround until runtime teams use suggested)
- then reverse natural order

Pre-selected version is the first one.

Add a unit test.

BREAKING-CHANGE:
- remove `MissionRuntimeService.getDefaultVersion` which became useless with the sort algo

Closes #313