### PR TITLE
fix(version): updates version of dep editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4830,9 +4830,9 @@
       "dev": true
     },
     "fabric8-analytics-dependency-editor": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/fabric8-analytics-dependency-editor/-/fabric8-analytics-dependency-editor-0.7.2.tgz",
-      "integrity": "sha512-18xuHmNZCOBaIzkBD+awB1Fd5lvATNppRI/eOAKJ1/HYyo2qIPLSGRzWDrWM0kHjq1Dh2hrTkJy8E+ud0ZLa4Q==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fabric8-analytics-dependency-editor/-/fabric8-analytics-dependency-editor-0.7.4.tgz",
+      "integrity": "sha512-vVeLaVEbKY5LNvUKl/ZLz0WVrBGAKpZgPBkFxCkrcZWP8GC39NrKLPfxRAcrds4/ShCVIcY7ABPsk4WBQQuQUA==",
       "requires": {
         "c3": "0.4.18",
         "ngx-base": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@thisissoon/angular-inviewport": "^1.3.2",
     "angular-2-dropdown-multiselect": "^1.6.0",
-    "fabric8-analytics-dependency-editor": "^0.7.2",
+    "fabric8-analytics-dependency-editor": "^0.7.4",
     "lodash": "^4.17.10",
     "ngx-base": "^2.3.2",
     "ngx-bootstrap": "^2.0.5",


### PR DESCRIPTION
Updates version of fabric8-analytics-dependency-editor to 0.7.4

- Avoids duplication of dependencies in added dependencies
- Avoids duplication of dependencies in core dependencies