### PR TITLE
fix(dep-checker): calls dep editor component only if it's enabled

### DIFF
--- a/src/app/launcher/create-app/dependency-editor-step/dependency-editor-step.component.html
+++ b/src/app/launcher/create-app/dependency-editor-step/dependency-editor-step.component.html
@@ -13,7 +13,7 @@
   <div>
     <div class="container-fluid container-cards-pf">
       <div class="row row-dep-editor">
-        <div class="col-xs-12">
+        <div class="col-xs-12" *ngIf="depEditorFlag">
           <app-dependency-editor [blankResponse]="blankResponse" [boosterInfo]="boosterInfo && boosterInfo" [githubUrl]="github && github" [githubRef]="gitref && gitref" [metadataInfo]="metadataInfo && metadataInfo"
           (depSnapshot)="pickDependencies($event)" [broadcaster]="broadcaster && broadcaster" (emitMetadata)="pickMetadata($event)" (navId)="navToStep($event)"></app-dependency-editor>
         </div>

--- a/src/app/launcher/create-app/dependency-editor-step/dependency-editor-step.component.ts
+++ b/src/app/launcher/create-app/dependency-editor-step/dependency-editor-step.component.ts
@@ -28,6 +28,7 @@ import { broadcast } from '../../shared/telemetry.decorator';
 })
 export class DependencyEditorCreateappStepComponent extends LauncherStep implements OnInit, OnDestroy, DoCheck {
     @Input() id: string;
+    @Input() depEditorFlag: boolean;
 
     public github: string = '';
     public gitref: string = '';

--- a/src/app/launcher/launcher.component.html
+++ b/src/app/launcher/launcher.component.html
@@ -26,6 +26,7 @@
           <f8launcher-dependencychecker-createapp-step
             [hidden]="flow === 'launch' || depEditorFlag !== true"
             [id]="'SelectDependencies'"
+            [depEditorFlag]="depEditorFlag"
             [styleClass]="'select-dependencies'"
             [title]="'Select Dependencies'">
           </f8launcher-dependencychecker-createapp-step>

--- a/src/app/launcher/launcher.component.spec.ts
+++ b/src/app/launcher/launcher.component.spec.ts
@@ -66,6 +66,7 @@ export class Fakef8launcherDependencyCheckeerCreatesppStep {
   @Input() hidden: boolean = false;
   @Input() styleClass: string;
   @Input() title: string;
+  @Input() depEditorFlag = false;
 }
 
 @Component({


### PR DESCRIPTION
Added a check to the dependency-editor-step-component to load the depenency-editor component only if feature flag is enabled.