### PR TITLE
fix: pipeline selection reacts on the runtime change

### DIFF
--- a/src/app/launcher/cancel-overlay/cancel-overlay.component.html
+++ b/src/app/launcher/cancel-overlay/cancel-overlay.component.html
@@ -1,4 +1,4 @@
-<div class="cancel-overlay" *ngIf="launcherComponent.showCancelOverlay === true">
+<div class="cancel-overlay" *ngIf="launcherComponent.showCancelOverlay  ">
   <div class="cancel-overlay-form">
     <form class="col-sm-4 col-sm-offset-4 cancel-overlay-form--step active" role="form">
       <section>

--- a/src/app/launcher/cancel-overlay/cancel-overlay.component.html
+++ b/src/app/launcher/cancel-overlay/cancel-overlay.component.html
@@ -1,4 +1,4 @@
-<div class="cancel-overlay" *ngIf="launcherComponent.showCancelOverlay  ">
+<div class="cancel-overlay" *ngIf="launcherComponent.showCancelOverlay">
   <div class="cancel-overlay-form">
     <form class="col-sm-4 col-sm-offset-4 cancel-overlay-form--step active" role="form">
       <section>

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
@@ -22,7 +22,8 @@ import {
 } from '../../service/mission-runtime.service.spec';
 import {
   BroadcasterTestProvider
-} from '../targetenvironment-createapp-step/target-environment-createapp-step.component.spec';
+}
+  from '../targetenvironment-createapp-step/target-environment-createapp-step.component.spec';
 import { Observable } from 'rxjs/Observable';
 import { Catalog } from '../../model/catalog.model';
 

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.ts
@@ -149,12 +149,12 @@ export class MissionRuntimeCreateappStepComponent extends LauncherStep implement
       this.versionId = newVersion.id;
       this.launcherComponent.summary.runtime = runtime;
       this.launcherComponent.summary.runtime.version = newVersion;
-
       // FIXME: use a booster change event listener to do this
       // set maven artifact
       if (this.launcherComponent.flow === 'osio' && this.completed) {
         this.launcherComponent.summary.dependencyCheck.mavenArtifact = this.createMavenArtifact();
       }
+      this.broadcaster.broadcast('runtime-changed', runtime);
     }
     this.handleBlankMissionFlow();
     this.updateBoosterViewStatus();

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.model.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.model.ts
@@ -23,6 +23,7 @@ export class ViewRuntime extends Runtime {
   prerequisite: boolean;
   canChangeVersion: boolean;
   suggested: boolean;
+  pipelinePlatform: string;
   selectedVersion: { id: string; name: string; };
   versions: BoosterVersion[];
   showMore: boolean = false;
@@ -59,6 +60,7 @@ export function createViewRuntimes(boosters: Booster[], canChangeVersion: boolea
       canChangeVersion: canChangeVersion,
       suggested: _.get(runtime, 'metadata.suggested', false),
       prerequisite: _.get(runtime, 'metadata.prerequisite', false),
+      pipelinePlatform: _.get(runtime, 'metadata.pipelinePlatform', false),
       showMore: false,
       disabled: true,
       boosters: runtimeBoosters

--- a/src/app/launcher/create-app/project-progress-createapp-nextstep/project-progress-createapp-nextstep.component.html
+++ b/src/app/launcher/create-app/project-progress-createapp-nextstep/project-progress-createapp-nextstep.component.html
@@ -9,7 +9,7 @@
   </div>
   <div>
     <div class="container-fluid container-cards-pf">
-      <div class="alert-box" *ngIf="isError  ">
+      <div class="alert-box" *ngIf="isError">
         <div class="alert alert-danger">
           <span class="pficon pficon-error-circle-o"></span>
           <strong>Set Up Incomplete</strong> There were some problems.
@@ -34,10 +34,10 @@
                 <span *ngIf="!allCompleted && !isError">
                   <i class="pficon pficon-in-progress fa-spin"></i> Working Through Setup
                 </span>
-                <span *ngIf="allCompleted   && isError !== true">
+                <span *ngIf="allCompleted && isError !== true">
                   <i class="pficon pficon-ok"></i> Your Application is Ready
                 </span>
-                <span *ngIf="isError  ">
+                <span *ngIf="isError">
                   <i class="pficon pficon-error-circle-o"></i> Set Up Incomplete
                 </span>
               </h2>
@@ -72,7 +72,7 @@
                 </div>
               </div>
             </div>
-            <div class="card-pf-body" *ngIf="launcherComponent.flow === 'launch' && allCompleted  ">
+            <div class="card-pf-body" *ngIf="launcherComponent.flow === 'launch' && allCompleted">
               <div class="list-pf">
                 <div class="list-pf-item">
                   <div class="list-pf-container">

--- a/src/app/launcher/create-app/project-progress-createapp-nextstep/project-progress-createapp-nextstep.component.html
+++ b/src/app/launcher/create-app/project-progress-createapp-nextstep/project-progress-createapp-nextstep.component.html
@@ -9,7 +9,7 @@
   </div>
   <div>
     <div class="container-fluid container-cards-pf">
-      <div class="alert-box" *ngIf="isError === true">
+      <div class="alert-box" *ngIf="isError  ">
         <div class="alert alert-danger">
           <span class="pficon pficon-error-circle-o"></span>
           <strong>Set Up Incomplete</strong> There were some problems.
@@ -34,10 +34,10 @@
                 <span *ngIf="!allCompleted && !isError">
                   <i class="pficon pficon-in-progress fa-spin"></i> Working Through Setup
                 </span>
-                <span *ngIf="allCompleted === true && isError !== true">
+                <span *ngIf="allCompleted   && isError !== true">
                   <i class="pficon pficon-ok"></i> Your Application is Ready
                 </span>
-                <span *ngIf="isError === true">
+                <span *ngIf="isError  ">
                   <i class="pficon pficon-error-circle-o"></i> Set Up Incomplete
                 </span>
               </h2>
@@ -72,7 +72,7 @@
                 </div>
               </div>
             </div>
-            <div class="card-pf-body" *ngIf="launcherComponent.flow === 'launch' && allCompleted === true">
+            <div class="card-pf-body" *ngIf="launcherComponent.flow === 'launch' && allCompleted  ">
               <div class="list-pf">
                 <div class="list-pf-item">
                   <div class="list-pf-container">

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -116,7 +116,7 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?.pipeline?.techPreview }">
+                   [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested || launcherComponent.summary?.pipeline?.techpreview}">
                 <div class="list-view-pf-main-info">
                   <div class="list-view-pf-body">
                     <div class="list-view-pf-description f8launcher-project-summary-data-unavailable dependency">
@@ -165,11 +165,11 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
-                <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
+                   [ngClass]="{'suggested': summary?.pipeline?.suggested || summary?.pipeline?.techPreview}">
+                <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested || summary?.pipeline?.techPreview}">
                   <div class="list-view-pf-expand">
                           <span class="fa"
-                                [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded  ,
+                                [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded,
                                             'fa-angle-right': summary?.pipeline?.expanded !== true}"
                                 (click)="toggleExpanded(summary.pipeline)">
                           </span>
@@ -190,25 +190,25 @@
                       </div>
                     </div>
                   </div>
-                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent.summary?.pipeline?.suggested  }"
-                        *ngIf="launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?. pipeline?.techPreview  ">
+                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent.summary?.pipeline?.suggested}"
+                        *ngIf="launcherComponent.summary?.pipeline?.suggested || launcherComponent.summary?.pipeline?.techpreview">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                          *ngIf="summary?.pipeline?.suggested  ">
+                          *ngIf="summary?.pipeline?.suggested">
                       Red Hat Suggests <i class="pficon pficon-info"></i>
                     </span>
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
-                          *ngIf="summary?.pipeline?.techPreview  ">
+                          *ngIf="summary?.pipeline?.techPreview">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                   </div>
                 </div>
                 <div class="list-group-item-container container-fluid"
                      (click)="pipelineId = summary?.pipeline?.id; updatePipelineSelection(pipeline)"
-                     *ngIf="summary?.pipeline?.expanded  ">
+                     *ngIf="summary?.pipeline?.expanded">
                   <div class="row">
                     <div class="form-horizontal">
                       <div class="form-group col-sm-12" *ngFor="let stage of summary?.pipeline?.stages">

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -116,7 +116,7 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true}">
+                   [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?.pipeline?.techpreview  }">
                 <div class="list-view-pf-main-info">
                   <div class="list-view-pf-body">
                     <div class="list-view-pf-description f8launcher-project-summary-data-unavailable dependency">
@@ -165,11 +165,11 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
-                <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
+                   [ngClass]="{'suggested': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
+                <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
                   <div class="list-view-pf-expand">
                           <span class="fa"
-                                [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded === true,
+                                [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded  ,
                                             'fa-angle-right': summary?.pipeline?.expanded !== true}"
                                 (click)="toggleExpanded(summary.pipeline)">
                           </span>
@@ -190,25 +190,25 @@
                       </div>
                     </div>
                   </div>
-                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent.summary?.pipeline?.suggested === true}"
-                        *ngIf="launcherComponent.summary?.pipeline?.suggested === true || launcherComponent.summary?.pipeline?.techpreview === true">
+                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent.summary?.pipeline?.suggested  }"
+                        *ngIf="launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?.pipeline?.techpreview  ">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                          *ngIf="summary?.pipeline?.suggested === true">
+                          *ngIf="summary?.pipeline?.suggested  ">
                       Red Hat Suggests <i class="pficon pficon-info"></i>
                     </span>
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
-                          *ngIf="summary?.pipeline?.techPreview === true">
+                          *ngIf="summary?.pipeline?.techPreview  ">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                   </div>
                 </div>
                 <div class="list-group-item-container container-fluid"
                      (click)="pipelineId = summary?.pipeline?.id; updatePipelineSelection(pipeline)"
-                     *ngIf="summary?.pipeline?.expanded === true">
+                     *ngIf="summary?.pipeline?.expanded  ">
                   <div class="row">
                     <div class="form-horizontal">
                       <div class="form-group col-sm-12" *ngFor="let stage of summary?.pipeline?.stages">

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -116,7 +116,7 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?.pipeline?.techpreview  }">
+                   [ngClass]="{'suggested': launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?.pipeline?.techPreview }">
                 <div class="list-view-pf-main-info">
                   <div class="list-view-pf-body">
                     <div class="list-view-pf-description f8launcher-project-summary-data-unavailable dependency">
@@ -191,7 +191,7 @@
                     </div>
                   </div>
                   <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent.summary?.pipeline?.suggested  }"
-                        *ngIf="launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?.pipeline?.techpreview  ">
+                        *ngIf="launcherComponent.summary?.pipeline?.suggested   || launcherComponent.summary?. pipeline?.techPreview  ">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."

--- a/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
+++ b/src/app/launcher/create-app/project-summary-createapp-step/project-summary-createapp-step.component.html
@@ -165,8 +165,8 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': summary?.pipeline?.suggested === true || summary?.pipeline?.techpreview === true}">
-                <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested === true || summary?.pipeline.techpreview === true}">
+                   [ngClass]="{'suggested': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
+                <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
                   <div class="list-view-pf-expand">
                           <span class="fa"
                                 [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded === true,
@@ -201,7 +201,7 @@
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
-                          *ngIf="summary?.pipeline?.techpreview === true">
+                          *ngIf="summary?.pipeline?.techPreview === true">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                   </div>

--- a/src/app/launcher/create-app/release-strategy-createapp-step/pipelines.fixture.spec.ts
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/pipelines.fixture.spec.ts
@@ -1,0 +1,267 @@
+import { Pipeline } from '../../model/pipeline.model';
+import { PipelineService } from '../../service/pipeline.service';
+import { Observable } from 'rxjs';
+
+export class StubbedPipelineService implements PipelineService {
+  getPipelines(filterByRuntime?: string): Observable<Pipeline[]> {
+    return Observable.of(pipelines());
+  }
+}
+
+export const mavenReleasePipeline: Pipeline = {
+  'id': 'maven-release',
+  'platform': 'maven',
+  'name': 'Release',
+  'description': 'Maven based pipeline which:\n\n' +
+    '* creates a new version then builds and deploys the project into the maven repository',
+  'stages': [{
+    'name': 'Build Release',
+    'description': 'creates a new version then builds and deploys the project into the maven repository'
+  }],
+  'suggested': false,
+  'techPreview': false
+};
+
+/**
+ * Data based on https://github.com/fabric8io/fabric8-jenkinsfile-library
+ */
+export function pipelines(): Pipeline[] {
+
+  return [{
+    'id': 'django-releaseandstage',
+    'platform': 'django',
+    'name': 'Release and Stage',
+    'description': 'Django based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'django-releasestageapproveandpromote',
+    'platform': 'django',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'Django based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, {
+    'id': 'dotnet-releaseandstage',
+    'platform': 'dotnet',
+    'name': 'Release and Stage',
+    'description': 'dotnet based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'dotnet-releasestageapproveandpromote',
+    'platform': 'dotnet',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'dotnet based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, {
+    'id': 'golang-releaseandstage',
+    'platform': 'golang',
+    'name': 'Release and Stage',
+    'description': 'Golang based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'golang-releasestageapproveandpromote',
+    'platform': 'golang',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'Golang based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, mavenReleasePipeline, {
+    'id': 'maven-releaseandstage',
+    'platform': 'maven',
+    'name': 'Release and Stage',
+    'description': 'Maven based pipeline which:\n\n' +
+      '* creates a new version then builds and deploys the project into the maven repository\n' +
+      '* stages the new version into the **Stage** environment',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'maven-releasestageapproveandpromote',
+    'platform': 'maven',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'Maven based pipeline which:\n\n' +
+      '* creates a new version then builds and deploys the project into the maven repository\n' +
+      '* stages the new version into the **Stage** environment\n' +
+      '* waits for **Approval** to promote \n' +
+      '* promotes to the **Run** environment',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, {
+    'id': 'node-releaseandstage',
+    'platform': 'node',
+    'name': 'Release and Stage',
+    'description': 'NodeJS based pipeline which creates a new version then builds and deploys the project ' +
+      'into the Nexus repository',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'node-releasestageapproveandpromote',
+    'platform': 'node',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'NodeJS based pipeline which creates a new version then builds and deploys the project ' +
+      'into the Nexus repository',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, {
+    'id': 'php-releaseandstage',
+    'platform': 'php',
+    'name': 'Release and Stage',
+    'description': 'PHP apache based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'php-releasestageapproveandpromote',
+    'platform': 'php',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'PHP apache based pipeline which creates a new version then builds and deploys the project',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, {
+    'id': 'rails-releaseandstage',
+    'platform': 'rails',
+    'name': 'Release and Stage',
+    'description': 'Ruby on Rails based pipeline which creates a new version then builds and deploys the project ' +
+      'into the Nexus repository',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'rails-releasestageapproveandpromote',
+    'platform': 'rails',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'Ruby on Rails based pipeline which creates a new version then builds and deploys the project ' +
+      'into the Nexus repository',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }, {
+    'id': 'swift-releaseandstage',
+    'platform': 'swift',
+    'name': 'Release and Stage',
+    'description': 'NodeJS based pipeline which creates a new version then builds and deploys the project ' +
+      'into the Nexus repository',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {'name': 'Rollout to Stage', 'description': 'stages the new version into the Stage environment'}],
+    'suggested': false,
+    'techPreview': false
+  }, {
+    'id': 'swift-releasestageapproveandpromote',
+    'platform': 'swift',
+    'name': 'Release, Stage, Approve and Promote',
+    'description': 'NodeJS based pipeline which creates a new version then builds and deploys the project ' +
+      'into the Nexus repository',
+    'stages': [{
+      'name': 'Build Release',
+      'description': 'creates a new version then builds and deploys the project into the maven repository'
+    }, {
+      'name': 'Rollout to Stage',
+      'description': 'stages the new version into the Stage environment'
+    }, {'name': 'Approve', 'description': 'waits for Approval to promote'}, {
+      'name': 'Rollout to Run',
+      'description': 'promotes to the Run environment'
+    }],
+    'suggested': true,
+    'techPreview': false
+  }] as Pipeline[];
+}

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
@@ -22,12 +22,12 @@
             <div class="card-pf-body">
               <div class="list-group list-view-pf list-view-pf-view">
                 <div class="list-group-item"
-                     [ngClass]="{'suggested': pipeline.suggested   || pipeline.techPreview  }"
+                     [ngClass]="{'suggested': pipeline.suggested || pipeline.techPreview}"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested   || pipeline.techPreview  }">
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested || pipeline.techPreview}">
                         <div class="list-view-pf-expand">
                               <span class="fa"
-                                    [ngClass]="{'fa-angle-down': pipeline.expanded  ,
+                                    [ngClass]="{'fa-angle-down': pipeline.expanded,
                                                 'fa-angle-right': pipeline.expanded !== true}"
                                     (click)="toggleExpanded(pipeline)">
                               </span>
@@ -54,18 +54,18 @@
                             </div>
                           </div>
                         </div>
-                        <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested  }"
-                              *ngIf="pipeline.suggested   || pipeline.techPreview  ">
+                        <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested}"
+                              *ngIf="pipeline.suggested || pipeline.techPreview">
                             <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                                   outsideClick="true"
                                   popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                                  *ngIf="pipeline.suggested  ">
+                                  *ngIf="pipeline.suggested">
                               Red Hat Suggests <i class="pficon pficon-info tag-icon"></i>
                             </span>
                             <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                                   outsideClick="true"
                                   popover="Technology Preview"
-                                  *ngIf="pipeline.techPreview  ">
+                                  *ngIf="pipeline.techPreview">
                               Tech Preview <i class="pficon pficon-info"></i>
                             </span>
                           </div>
@@ -75,7 +75,7 @@
 
                   <div class="list-group-item-container container-fluid"
                        (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)"
-                       *ngIf="pipeline.expanded  ">
+                       *ngIf="pipeline.expanded">
                     <div class="row">
                       <div class="form-horizontal">
                         <div class="form-group col-sm-12" *ngFor="let stage of pipeline.stages">

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
@@ -22,9 +22,9 @@
             <div class="card-pf-body">
               <div class="list-group list-view-pf list-view-pf-view">
                 <div class="list-group-item"
-                     [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techpreview === true}"
+                     [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techPreview === true}"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techpreview === true}">
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techPreview === true}">
                         <div class="list-view-pf-expand">
                               <span class="fa"
                                     [ngClass]="{'fa-angle-down': pipeline.expanded === true,
@@ -55,7 +55,7 @@
                           </div>
                         </div>
                         <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested === true}"
-                              *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
+                              *ngIf="pipeline.suggested === true || pipeline.techPreview === true">
                             <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                                   outsideClick="true"
                                   popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
@@ -65,7 +65,7 @@
                             <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                                   outsideClick="true"
                                   popover="Technology Preview"
-                                  *ngIf="pipeline.techpreview === true">
+                                  *ngIf="pipeline.techPreview === true">
                               Tech Preview <i class="pficon pficon-info"></i>
                             </span>
                           </div>

--- a/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
+++ b/src/app/launcher/create-app/release-strategy-createapp-step/release-strategy-createapp-step.component.html
@@ -22,12 +22,12 @@
             <div class="card-pf-body">
               <div class="list-group list-view-pf list-view-pf-view">
                 <div class="list-group-item"
-                     [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techPreview === true}"
+                     [ngClass]="{'suggested': pipeline.suggested   || pipeline.techPreview  }"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techPreview === true}">
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested   || pipeline.techPreview  }">
                         <div class="list-view-pf-expand">
                               <span class="fa"
-                                    [ngClass]="{'fa-angle-down': pipeline.expanded === true,
+                                    [ngClass]="{'fa-angle-down': pipeline.expanded  ,
                                                 'fa-angle-right': pipeline.expanded !== true}"
                                     (click)="toggleExpanded(pipeline)">
                               </span>
@@ -54,18 +54,18 @@
                             </div>
                           </div>
                         </div>
-                        <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested === true}"
-                              *ngIf="pipeline.suggested === true || pipeline.techPreview === true">
+                        <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested  }"
+                              *ngIf="pipeline.suggested   || pipeline.techPreview  ">
                             <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                                   outsideClick="true"
                                   popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                                  *ngIf="pipeline.suggested === true">
+                                  *ngIf="pipeline.suggested  ">
                               Red Hat Suggests <i class="pficon pficon-info tag-icon"></i>
                             </span>
                             <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                                   outsideClick="true"
                                   popover="Technology Preview"
-                                  *ngIf="pipeline.techPreview === true">
+                                  *ngIf="pipeline.techPreview  ">
                               Tech Preview <i class="pficon pficon-info"></i>
                             </span>
                           </div>
@@ -75,7 +75,7 @@
 
                   <div class="list-group-item-container container-fluid"
                        (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)"
-                       *ngIf="pipeline.expanded === true">
+                       *ngIf="pipeline.expanded  ">
                     <div class="row">
                       <div class="form-horizontal">
                         <div class="form-group col-sm-12" *ngFor="let stage of pipeline.stages">

--- a/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.html
+++ b/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.html
@@ -9,7 +9,7 @@
   </div>
   <div>
     <div class="container-fluid container-cards-pf">
-      <div class="alert-box" *ngIf="isError  ">
+      <div class="alert-box" *ngIf="isError">
           <div class="alert alert-danger">
               <span class="pficon pficon-error-circle-o"></span>
               <strong>Set Up Incomplete</strong> There were some problems.
@@ -33,10 +33,10 @@
                 <span *ngIf="allCompleted !== true">
                   <i class="pficon pficon-in-progress fa-spin"></i> Working Through Setup
                 </span>
-                <span *ngIf="allCompleted   && isError !== true">
+                <span *ngIf="allCompleted && isError !== true">
                   <i class="pficon pficon-ok"></i> Your Application is Ready
                 </span>
-                <span *ngIf="isError  ">
+                <span *ngIf="isError">
                   <i class="pficon pficon-error-circle-o"></i> Set Up Incomplete
                 </span>
               </h2>
@@ -50,7 +50,7 @@
                         <div class="list-pf-left"
                                 [ngClass]="{'item-in-progress': item.completed !== true}">
                           <span class="pficon"
-                                [ngClass]="{'pficon-ok': item.completed  ,
+                                [ngClass]="{'pficon-ok': item.completed,
                                             'pficon-in-progress fa-spin': item.completed !== true,
                                             'icon-clear': item.completed !== true && item.inProgress !== true}">
                           </span>
@@ -62,7 +62,7 @@
                           </div>
                         </div>
                         <div class="list-pf-actions"
-                          *ngIf="item?.hyperText !== undefined && item?.completed  ">
+                          *ngIf="item?.hyperText !== undefined && item?.completed">
                           <a target="_blank" [href]="item?.hyperText">{{item?.hyperText}}</a>
                         </div>
                       </div>

--- a/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.html
+++ b/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.html
@@ -9,7 +9,7 @@
   </div>
   <div>
     <div class="container-fluid container-cards-pf">
-      <div class="alert-box" *ngIf="isError === true">
+      <div class="alert-box" *ngIf="isError  ">
           <div class="alert alert-danger">
               <span class="pficon pficon-error-circle-o"></span>
               <strong>Set Up Incomplete</strong> There were some problems.
@@ -33,10 +33,10 @@
                 <span *ngIf="allCompleted !== true">
                   <i class="pficon pficon-in-progress fa-spin"></i> Working Through Setup
                 </span>
-                <span *ngIf="allCompleted === true && isError !== true">
+                <span *ngIf="allCompleted   && isError !== true">
                   <i class="pficon pficon-ok"></i> Your Application is Ready
                 </span>
-                <span *ngIf="isError === true">
+                <span *ngIf="isError  ">
                   <i class="pficon pficon-error-circle-o"></i> Set Up Incomplete
                 </span>
               </h2>
@@ -50,7 +50,7 @@
                         <div class="list-pf-left"
                                 [ngClass]="{'item-in-progress': item.completed !== true}">
                           <span class="pficon"
-                                [ngClass]="{'pficon-ok': item.completed === true,
+                                [ngClass]="{'pficon-ok': item.completed  ,
                                             'pficon-in-progress fa-spin': item.completed !== true,
                                             'icon-clear': item.completed !== true && item.inProgress !== true}">
                           </span>
@@ -62,7 +62,7 @@
                           </div>
                         </div>
                         <div class="list-pf-actions"
-                          *ngIf="item?.hyperText !== undefined && item?.completed === true">
+                          *ngIf="item?.hyperText !== undefined && item?.completed  ">
                           <a target="_blank" [href]="item?.hyperText">{{item?.hyperText}}</a>
                         </div>
                       </div>

--- a/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.spec.ts
+++ b/src/app/launcher/import-app/project-progress-importapp-nextstep/project-progress-importapp-nextstep.component.spec.ts
@@ -1,13 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
-import { By } from '@angular/platform-browser';
 import { Observable, Subject } from 'rxjs';
 
 import { ProjectProgressImportappNextstepComponent } from './project-progress-importapp-nextstep.component';
 import { ProjectProgressService } from '../../service/project-progress.service';
 import { Progress } from '../../model/progress.model';
 import { LauncherComponent } from '../../launcher.component';
-import { LauncherStep } from '../../launcher-step';
 
 let progressSubject: Subject<Progress[]> = new Subject();
 let mockProjectProgressService = {
@@ -18,17 +16,14 @@ let mockProjectProgressService = {
     let progress = [{
       'completed': false,
       'description': 'Creating Your Project on the OpenShift Cloud',
-      'inProgress': false,
       'hypertext': 'View New Application',
       'url': 'https://github.com/fabric8-launcher/ngx-launcher'
     }, {
       'completed': false,
-      'description': 'Setting up Build Pipeline',
-      'inProgress': false
+      'description': 'Setting up Build Pipeline'
     }, {
       'completed': false,
-      'description': 'Configure Trigger Builds on Git Pushes',
-      'inProgress': false
+      'description': 'Configure Trigger Builds on Git Pushes'
     }] as Progress[];
     return progress;
   }

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -37,8 +37,8 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': summary?.pipeline?.suggested === true || summary?.pipeline?.techpreview === true}">
-                   <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested === true || summary?.pipeline.techpreview === true}">
+                   [ngClass]="{'suggested': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
+                   <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
                 <div class="list-view-pf-expand">
                         <span class="fa"
                               [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded === true,
@@ -73,7 +73,7 @@
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
-                          *ngIf="summary?.pipeline?.techpreview === true">
+                          *ngIf="summary?.pipeline?.techPreview === true">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                   </div>

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -37,11 +37,11 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
-                   <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
+                   [ngClass]="{'suggested': summary?.pipeline?.suggested || summary?.pipeline?.techPreview}">
+                   <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested || summary?.pipeline?.techPreview}">
                 <div class="list-view-pf-expand">
                         <span class="fa"
-                              [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded  ,
+                              [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded,
                                           'fa-angle-right': summary?.pipeline?.expanded !== true}"
                               (click)="toggleExpanded(summary?.pipeline)">
                         </span>
@@ -62,25 +62,25 @@
                     </div>
                   </div>
                 </div>
-                <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent?.summary?.pipeline?.suggested  }"
-                       *ngIf="launcherComponent?.summary?.pipeline?.suggested   || launcherComponent?.summary?.pipeline?.techPreview  ">
+                <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent?.summary?.pipeline?.suggested}"
+                       *ngIf="launcherComponent?.summary?.pipeline?.suggested || launcherComponent?.summary?.pipeline?.techpreview">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                          *ngIf="summary?.pipeline?.suggested  ">
+                          *ngIf="summary?.pipeline?.suggested">
                       Red Hat Suggests <i class="pficon pficon-info"></i>
                     </span>
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
-                          *ngIf="summary?.pipeline?.techPreview  ">
+                          *ngIf="summary?.pipeline?.techPreview">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                   </div>
                 </div>
                 <div class="list-group-item-container container-fluid"
                      (click)="pipelineId = summary?.pipeline?.id; updatePipelineSelection(pipeline)"
-                     *ngIf="summary?.pipeline?.expanded  ">
+                     *ngIf="summary?.pipeline?.expanded">
                   <div class="row">
                     <div class="form-horizontal">
                       <div class="form-group col-sm-12" *ngFor="let stage of summary?.pipeline?.stages">

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -63,7 +63,7 @@
                   </div>
                 </div>
                 <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent?.summary?.pipeline?.suggested  }"
-                       *ngIf="launcherComponent?.summary?.pipeline?.suggested   || launcherComponent?.summary?. pipeline?.techPreview  ">
+                       *ngIf="launcherComponent?.summary?.pipeline?.suggested   || launcherComponent?.summary?.pipeline?.techPreview  ">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -63,7 +63,7 @@
                   </div>
                 </div>
                 <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent?.summary?.pipeline?.suggested  }"
-                       *ngIf="launcherComponent?.summary?.pipeline?.suggested   || launcherComponent?.summary?.pipeline?.techpreview  ">
+                       *ngIf="launcherComponent?.summary?.pipeline?.suggested   || launcherComponent?.summary?. pipeline?.techPreview  ">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."

--- a/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
+++ b/src/app/launcher/import-app/project-summary-importapp-step/project-summary-importapp-step.component.html
@@ -37,11 +37,11 @@
             </div>
             <div class="card-pf-body">
               <div class="list-group-item"
-                   [ngClass]="{'suggested': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
-                   <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested === true || summary?.pipeline?.techPreview === true}">
+                   [ngClass]="{'suggested': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
+                   <div class="group" [ngClass]="{'with-tag': summary?.pipeline?.suggested   || summary?.pipeline?.techPreview  }">
                 <div class="list-view-pf-expand">
                         <span class="fa"
-                              [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded === true,
+                              [ngClass]="{'fa-angle-down': summary?.pipeline?.expanded  ,
                                           'fa-angle-right': summary?.pipeline?.expanded !== true}"
                               (click)="toggleExpanded(summary?.pipeline)">
                         </span>
@@ -62,25 +62,25 @@
                     </div>
                   </div>
                 </div>
-                <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent?.summary?.pipeline?.suggested === true}"
-                       *ngIf="launcherComponent?.summary?.pipeline?.suggested === true || launcherComponent?.summary?.pipeline?.techpreview === true">
+                <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': launcherComponent?.summary?.pipeline?.suggested  }"
+                       *ngIf="launcherComponent?.summary?.pipeline?.suggested   || launcherComponent?.summary?.pipeline?.techpreview  ">
                     <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                           outsideClick="true"
                           popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                          *ngIf="summary?.pipeline?.suggested === true">
+                          *ngIf="summary?.pipeline?.suggested  ">
                       Red Hat Suggests <i class="pficon pficon-info"></i>
                     </span>
                     <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                           outsideClick="true"
                           popover="Technology Preview"
-                          *ngIf="summary?.pipeline?.techPreview === true">
+                          *ngIf="summary?.pipeline?.techPreview  ">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                   </div>
                 </div>
                 <div class="list-group-item-container container-fluid"
                      (click)="pipelineId = summary?.pipeline?.id; updatePipelineSelection(pipeline)"
-                     *ngIf="summary?.pipeline?.expanded === true">
+                     *ngIf="summary?.pipeline?.expanded  ">
                   <div class="row">
                     <div class="form-horizontal">
                       <div class="form-group col-sm-12" *ngFor="let stage of summary?.pipeline?.stages">

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
@@ -22,12 +22,12 @@
             <div class="card-pf-body">
               <div class="list-group list-view-pf list-view-pf-view">
                 <div class="list-group-item"
-                     [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techPreview === true}"
+                     [ngClass]="{'suggested': pipeline.suggested   || pipeline.techPreview  }"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techPreview === true}">
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested   || pipeline.techPreview  }">
                   <div class="list-view-pf-expand">
                         <span class="fa"
-                              [ngClass]="{'fa-angle-down': pipeline.expanded === true,
+                              [ngClass]="{'fa-angle-down': pipeline.expanded  ,
                                           'fa-angle-right': pipeline.expanded !== true}"
                               (click)="toggleExpanded(pipeline)">
                         </span>
@@ -54,25 +54,25 @@
                       </div>
                     </div>
                   </div>
-                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested === true}"
-                         *ngIf="pipeline.suggested === true || pipeline.techPreview === true">
+                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested  }"
+                         *ngIf="pipeline.suggested   || pipeline.techPreview  ">
                       <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                            *ngIf="pipeline.suggested === true">
+                            *ngIf="pipeline.suggested  ">
                         Red Hat Suggests <i class="pficon pficon-info"></i>
                       </span>
                       <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                             outsideClick="true"
                             popover="Technology Preview"
-                            *ngIf="pipeline.techPreview === true">
+                            *ngIf="pipeline.techPreview  ">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                     </div>
                   </div>
                   <div class="list-group-item-container container-fluid"
                        (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)"
-                       *ngIf="pipeline.expanded === true">
+                       *ngIf="pipeline.expanded  ">
                     <div class="row">
                       <div class="form-horizontal">
                         <div class="form-group col-sm-12" *ngFor="let stage of pipeline.stages">

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
@@ -22,9 +22,9 @@
             <div class="card-pf-body">
               <div class="list-group list-view-pf list-view-pf-view">
                 <div class="list-group-item"
-                     [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techpreview === true}"
+                     [ngClass]="{'suggested': pipeline.suggested === true || pipeline.techPreview === true}"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techpreview === true}">
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested === true || pipeline.techPreview === true}">
                   <div class="list-view-pf-expand">
                         <span class="fa"
                               [ngClass]="{'fa-angle-down': pipeline.expanded === true,
@@ -55,7 +55,7 @@
                     </div>
                   </div>
                   <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested === true}"
-                         *ngIf="pipeline.suggested === true || pipeline.techpreview === true">
+                         *ngIf="pipeline.suggested === true || pipeline.techPreview === true">
                       <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
@@ -65,7 +65,7 @@
                       <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                             outsideClick="true"
                             popover="Technology Preview"
-                            *ngIf="pipeline.techpreview === true">
+                            *ngIf="pipeline.techPreview === true">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                     </div>

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.html
@@ -22,12 +22,12 @@
             <div class="card-pf-body">
               <div class="list-group list-view-pf list-view-pf-view">
                 <div class="list-group-item"
-                     [ngClass]="{'suggested': pipeline.suggested   || pipeline.techPreview  }"
+                     [ngClass]="{'suggested': pipeline.suggested || pipeline.techPreview}"
                      *ngFor="let pipeline of (pipelines | sortArray: 'suggested': true)">
-                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested   || pipeline.techPreview  }">
+                     <div class="group" [ngClass]="{'with-tag': pipeline.suggested || pipeline.techPreview}">
                   <div class="list-view-pf-expand">
                         <span class="fa"
-                              [ngClass]="{'fa-angle-down': pipeline.expanded  ,
+                              [ngClass]="{'fa-angle-down': pipeline.expanded,
                                           'fa-angle-right': pipeline.expanded !== true}"
                               (click)="toggleExpanded(pipeline)">
                         </span>
@@ -54,25 +54,25 @@
                       </div>
                     </div>
                   </div>
-                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested  }"
-                         *ngIf="pipeline.suggested   || pipeline.techPreview  ">
+                  <div class="f8launcher-tags" [ngClass]="{'suggested-feature-tag': pipeline.suggested}"
+                         *ngIf="pipeline.suggested || pipeline.techPreview">
                       <span class="f8launcher-tags-label suggested" container="body" triggers="click"
                             outsideClick="true"
                             popover="This pipeline provides an end-to-end process that moves your application from source code to production, with stages to build and test new versions, rollout to staging, review changes, await approval, and promote to production."
-                            *ngIf="pipeline.suggested  ">
+                            *ngIf="pipeline.suggested">
                         Red Hat Suggests <i class="pficon pficon-info"></i>
                       </span>
                       <span class="f8launcher-tags-label techpreview" container="body" triggers="click"
                             outsideClick="true"
                             popover="Technology Preview"
-                            *ngIf="pipeline.techPreview  ">
+                            *ngIf="pipeline.techPreview">
                         Tech Preview <i class="pficon pficon-info"></i>
                       </span>
                     </div>
                   </div>
                   <div class="list-group-item-container container-fluid"
                        (click)="pipelineId = pipeline.id; updatePipelineSelection(pipeline)"
-                       *ngIf="pipeline.expanded  ">
+                       *ngIf="pipeline.expanded">
                     <div class="row">
                       <div class="form-horizontal">
                         <div class="form-group col-sm-12" *ngFor="let stage of pipeline.stages">

--- a/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.spec.ts
+++ b/src/app/launcher/import-app/release-strategy-importapp-step/release-strategy-importapp-step.component.spec.ts
@@ -8,14 +8,13 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Observable } from 'rxjs';
 import { InViewportModule, WindowRef } from '@thisissoon/angular-inviewport';
 
-  import { FilterEvent } from 'patternfly-ng/filter';
-  import { SortArrayPipeModule } from 'patternfly-ng/pipe';
-  import { SortEvent } from 'patternfly-ng/sort';
+import { FilterEvent } from 'patternfly-ng/filter';
+import { SortArrayPipeModule } from 'patternfly-ng/pipe';
+import { SortEvent } from 'patternfly-ng/sort';
 
 import { LauncherComponent } from '../../launcher.component';
 import { LauncherStep } from '../../launcher-step';

--- a/src/app/launcher/launcher.component.html
+++ b/src/app/launcher/launcher.component.html
@@ -1,4 +1,4 @@
-<f8launcher-cancel-overlay *ngIf="showCancelOverlay === true"></f8launcher-cancel-overlay>
+<f8launcher-cancel-overlay *ngIf="showCancelOverlay  "></f8launcher-cancel-overlay>
 <div class="f8launcher">
   <div class="f8launcher-container">
     <div *ngIf="importApp; then showImportAppTemplate else showCreateAppTemplate"></div>
@@ -37,7 +37,7 @@
             [title]="'Select Pipeline'">
           </f8launcher-releasestrategy-createapp-step>
           <f8launcher-gitprovider-createapp-step
-            [hidden]="flow === 'launch' && !(summary?.targetEnvironment === 'os' && targetEnvStep.completed === true)"
+            [hidden]="flow === 'launch' && !(summary?.targetEnvironment === 'os' && targetEnvStep.completed  )"
             [id]="'GitProvider'"
             [styleClass]="'git-provider'"
             [title]="'Authorize Git Provider'">

--- a/src/app/launcher/launcher.component.html
+++ b/src/app/launcher/launcher.component.html
@@ -1,4 +1,4 @@
-<f8launcher-cancel-overlay *ngIf="showCancelOverlay  "></f8launcher-cancel-overlay>
+<f8launcher-cancel-overlay *ngIf="showCancelOverlay"></f8launcher-cancel-overlay>
 <div class="f8launcher">
   <div class="f8launcher-container">
     <div *ngIf="importApp; then showImportAppTemplate else showCreateAppTemplate"></div>
@@ -37,7 +37,7 @@
             [title]="'Select Pipeline'">
           </f8launcher-releasestrategy-createapp-step>
           <f8launcher-gitprovider-createapp-step
-            [hidden]="flow === 'launch' && !(summary?.targetEnvironment === 'os' && targetEnvStep.completed  )"
+            [hidden]="flow === 'launch' && !(summary?.targetEnvironment === 'os' && targetEnvStep.completed)"
             [id]="'GitProvider'"
             [styleClass]="'git-provider'"
             [title]="'Authorize Git Provider'">

--- a/src/app/launcher/model/pipeline.model.ts
+++ b/src/app/launcher/model/pipeline.model.ts
@@ -3,10 +3,11 @@ export class Pipeline {
   name: string;
   id: string;
   platform: string;
+  description?: string;
   stages: [{
     description: string;
     name: string;
   }];
   suggested?: boolean;
-  techpreview?: boolean;
+  techPreview?: boolean;
 }

--- a/src/app/launcher/service/mission-runtime.service.spec.ts
+++ b/src/app/launcher/service/mission-runtime.service.spec.ts
@@ -28,7 +28,7 @@ export const createRuntime = (name: string, versions: string[]): CatalogRuntime 
     suggested: true,
     prerequisite: 'prerequisite text'
   },
-  versions: versions.map(createVersion) as CatalogRuntimeVersion[]
+  versions: versions.map(version => createVersion(version)) as CatalogRuntimeVersion[]
 });
 
 export const createBooster = (mission: string, runtime: string, version: string): CatalogBooster => ({

--- a/src/app/launcher/step-indicator/step-indicator.component.html
+++ b/src/app/launcher/step-indicator/step-indicator.component.html
@@ -14,14 +14,14 @@
   </span>
 </div>
 <div class="f8launcher-vertical-bar"
-     [ngClass]="{'in-progress': inProgress  }">
+     [ngClass]="{'in-progress': inProgress}">
   <a class="f8launcher-vertical-bar_steps--item {{step.styleClass}}" href="javascript:void(0)"
      [class.active]="launcherComponent.selectedSection === step.id"
-     [ngClass]="{'hide': step.hidden  }"
+     [ngClass]="{'hide': step.hidden}"
      (click)="navToStep(step.id)"
      *ngFor="let step of launcherComponent.steps">
     <div class="f8launcher-step-circle"
-         [ngClass]="{'completed': step.completed  }">
+         [ngClass]="{'completed': step.completed}">
     </div>
     <span class="f8launcher-vertical-bar_steps--title">{{step.title}}</span>
   </a>

--- a/src/app/launcher/step-indicator/step-indicator.component.html
+++ b/src/app/launcher/step-indicator/step-indicator.component.html
@@ -14,14 +14,14 @@
   </span>
 </div>
 <div class="f8launcher-vertical-bar"
-     [ngClass]="{'in-progress': inProgress === true}">
+     [ngClass]="{'in-progress': inProgress  }">
   <a class="f8launcher-vertical-bar_steps--item {{step.styleClass}}" href="javascript:void(0)"
      [class.active]="launcherComponent.selectedSection === step.id"
-     [ngClass]="{'hide': step.hidden === true}"
+     [ngClass]="{'hide': step.hidden  }"
      (click)="navToStep(step.id)"
      *ngFor="let step of launcherComponent.steps">
     <div class="f8launcher-step-circle"
-         [ngClass]="{'completed': step.completed === true}">
+         [ngClass]="{'completed': step.completed  }">
     </div>
     <span class="f8launcher-vertical-bar_steps--title">{{step.title}}</span>
   </a>


### PR DESCRIPTION
### Current behavior

Pipeline selection is loaded once when the Step is initialized and always defaults to `maven` runtime. This blocks usage of other runtimes such as `nodejs`.

### Proposed Fix

  * broadcasts event on runtime change with pipeline platform specified
  * pipeline selection step observes on it and updates pipeline selection
  * if changed runtime has different pipeline platform it will reset the selection

Part of openshiftio/openshift.io#4140

Respective changes on fabric8-ui https://github.com/fabric8-ui/fabric8-ui/pull/3242