### PR TITLE
fix: show version dropdown when runtime is selected

### DIFF
--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.html
@@ -202,7 +202,7 @@
                       <div class="list-view-pf-description">
                         <div class="list-group-item-heading">
                           {{runtime.name}}
-                          <div *ngIf="!runtime.disabled && canChangeVersion && missionId && runtime.id == runtimeId" class="dropdown" dropdown>
+                          <div *ngIf="!runtime.disabled && canChangeVersion && runtime.id == runtimeId" class="dropdown" dropdown>
                             <button type="button" class="btn btn-default dropdown-toggle" dropdownToggle
                                     [disabled]="runtime.disabled">
                               {{runtime.selectedVersion.name}}

--- a/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
+++ b/src/app/launcher/create-app/mission-runtime-createapp-step/mission-runtime-createapp-step.component.spec.ts
@@ -390,13 +390,9 @@ describe('MissionRuntimeStepComponent', () => {
   }));
 
   it(`should show versions dropdown only when canChangeVersion is true
-   and mission and runtime are selected`, fakeAsync(() => {
+   and runtime are selected`, fakeAsync(() => {
     component.canChangeVersion = true;
     fixture.detectChanges();
-    expect(getRuntimeItem(0).querySelector('.dropdown')).toBeFalsy();
-    expect(getRuntimeItem(1).querySelector('.dropdown')).toBeFalsy();
-
-    selectItem(getMissionItem(0));
     expect(getRuntimeItem(0).querySelector('.dropdown')).toBeFalsy();
     expect(getRuntimeItem(1).querySelector('.dropdown')).toBeFalsy();
 


### PR DESCRIPTION
To see the auto-change behavior:
1- Deployment: zip
2- Choose runtime `Node` with version `10.x (RHOAR)`
3- Choose mission `Istio - Circuit Breaker`
=> Version has changed to 8.x `(Community)`

Fixes https://github.com/fabric8-launcher/launcher-frontend/issues/648