### PR TITLE
fix: use unique name to store creator runtime name will override the mission-runtime

### DIFF
--- a/projects/ngx-launcher/src/lib/components/runtime-step/runtime-step.component.ts
+++ b/projects/ngx-launcher/src/lib/components/runtime-step/runtime-step.component.ts
@@ -29,9 +29,7 @@ export class RuntimeStepComponent extends LauncherStep implements OnInit {
 
   ngOnInit(): void {
     const state = new StepState(this.selectedRuntime,
-      [
-        { name: 'runtime', value: 'value' }
-      ]
+      [{ name: 'creator-runtime', value: 'value' }]
     );
     this.projectile.setState(this.id, state);
     if (this.launcherComponent) {


### PR DESCRIPTION
fixes: https://github.com/fabric8-launcher/launcher-frontend/issues/785