### PR TITLE
fix: reverted parameter names to the correct values

### DIFF
--- a/projects/ngx-launcher/src/lib/model/projectile.model.spec.ts
+++ b/projects/ngx-launcher/src/lib/model/projectile.model.spec.ts
@@ -76,7 +76,7 @@ describe('State saving and restoring', () => {
     class SharedStateProjectile<T> extends Projectile<T> {
       protected searchParams() {
         // tslint:disable-next-line:max-line-length
-        return new URLSearchParams('?selectedSection=&shared=%7B%22projectName%22%3A%22projectName%22%2C%22projectVersion%22%3A%22%22%2C%22groupId%22%3A%22%22%2C%22mavenArtifact%22%3A%22some-value%22%2C%22space%22%3A%22%22%2C%22targetEnvironment%22%3A%22%22%7D');
+        return new URLSearchParams('?selectedSection=&shared=%7B%22projectName%22%3A%22projectName%22%2C%22projectVersion%22%3A%22%22%2C%22groupId%22%3A%22%22%2C%22artifactId%22%3A%22some-value%22%2C%22space%22%3A%22%22%2C%22targetEnvironment%22%3A%22%22%7D');
       }
     }
 
@@ -84,7 +84,7 @@ describe('State saving and restoring', () => {
     projectile.sharedState.state;
     projectile.restore('shared', projectile.getSavedState('shared'));
     expect(projectile.sharedState.state.projectName).toBe('projectName');
-    expect(projectile.sharedState.state.mavenArtifact).toBe('some-value');
+    expect(projectile.sharedState.state.artifactId).toBe('some-value');
   });
 
   it('should reset the state of the component', async(() => {

--- a/projects/ngx-launcher/src/lib/model/projectile.model.ts
+++ b/projects/ngx-launcher/src/lib/model/projectile.model.ts
@@ -29,8 +29,8 @@ export class Projectile<T> {
         { name: 'projectName', value: 'projectName' },
         { name: 'projectVersion', value: 'projectVersion' },
         { name: 'groupId', value: 'groupId' },
-        { name: 'mavenArtifact', value: 'mavenArtifact' },
-        { name: 'spacePath', value: 'spacePath' },
+        { name: 'mavenArtifact', value: 'artifactId' },
+        { name: 'spacePath', value: 'space' },
         { name: 'targetEnvironment', value: 'targetEnvironment' }
       ]);
       this.setState('shared', state);


### PR DESCRIPTION
This fixes the parameter names renamed erroneously in https://github.com/fabric8-launcher/ngx-launcher/commit/191f99d020b116183aa493fc6e5ec0a944eb4fd1